### PR TITLE
feat(#42): 서버 멤버목록 조회기능 추가

### DIFF
--- a/exbackend/src/domain/server/controllers/server.controller.ts
+++ b/exbackend/src/domain/server/controllers/server.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Post, Get, Body, Param, ParseIntPipe, Patch, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { ServerCreationService } from '../services/server-creation.service';
-import { ServerInvitationService } from '../services/server-invitation.service';
+import { ServerInvitationService, ServerMemberInfoDto, ServerMemberDetailDto } from '../services/server-invitation.service';
 import { CreateServerDto, ServerListDto, ServerCreateResponseDto } from '../dto';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { CurrentUser } from '../../auth/current-user.decorator';
@@ -193,6 +193,20 @@ export class ServerController {
         profile_image_path: result.userInfo.profile_image_path
       }
     };
+  }
+
+  @Get(':serverUrl/members')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '서버 멤버 목록 조회' })
+  @ApiResponse({ status: 200, description: '멤버 목록 조회 성공' })
+  async getServerMembers(
+    @Param('serverUrl') serverUrl: string,
+    @CurrentUser() user: User
+  ): Promise<ServerMemberInfoDto[] | ServerMemberDetailDto[]> {
+    const requestUserPk = user.userPk;
+    
+    return await this.serverInvitationService.getServerMembersByUrl(serverUrl, requestUserPk);
   }
 
 }

--- a/exbackend/src/domain/server/services/server-invitation.service.ts
+++ b/exbackend/src/domain/server/services/server-invitation.service.ts
@@ -7,7 +7,7 @@ import { Server } from '../entities/server.entity';
 import { ServerMember } from '../entities/server-member.entity';
 import { User } from '../../user/entities/user.entity';
 import { UserService } from '../../user/services/user.service';
-import { ServerRoleUtils } from '../../../common/enums/member-role.enum';
+import { ServerRoleUtils, ServerRoleType } from '../../../common/enums/member-role.enum';
 import { Project } from '../../project/entities/project.entity';
 import { Channel } from '../../text-channel/entities/channel.entity';
 
@@ -41,6 +41,19 @@ export interface PendingMemberDto {
     channelPk: number;
     channelName: string;
   };
+}
+
+export interface ServerMemberInfoDto {
+  userInfo: {
+    userName: string;
+    userEmail: string;
+    profileImagePath: string;
+  };
+}
+
+export interface ServerMemberDetailDto extends ServerMemberInfoDto {
+  status: 'Active' | 'Inactive' | 'Banned';
+  serverRole: ServerRoleType;
 }
 
 export interface UpdateMemberStatusDto {
@@ -562,5 +575,65 @@ export class ServerInvitationService {
     // 6. 논리적 삭제 (상태를 'Banned'로 변경)
     targetMember.status = 'Banned';
     await this.serverMemberRepository.save(targetMember);
+  }
+
+  // serverUrl로 서버 멤버 목록 조회 (권한에 따라 다른 정보 반환)
+  async getServerMembersByUrl(
+    serverUrl: string, 
+    requestUserPk: number
+  ): Promise<ServerMemberInfoDto[] | ServerMemberDetailDto[]> {
+    // 1. 서버 존재 확인
+    const server = await this.serverRepository.findOne({
+      where: { serverUrl, isDeletedServer: false }
+    });
+
+    if (!server) {
+      throw new NotFoundException(`Server with URL ${serverUrl} not found`);
+    }
+
+    // 2. 요청자의 서버 멤버 정보 확인
+    const requestMember = await this.serverMemberRepository.findOne({
+      where: { 
+        serverPk: server.serverPk, 
+        userPk: requestUserPk, 
+        status: 'Approved'
+      }
+    });
+
+    if (!requestMember) {
+      throw new ForbiddenException('Only server members can view member list');
+    }
+
+    // 3. 승인된 멤버 목록 조회
+    const activeMembers = await this.serverMemberRepository.find({
+      where: { serverPk: server.serverPk, status: 'Approved' },
+      relations: ['user'],
+      order: { serverMemberPk: 'ASC' },
+    });
+
+    // 4. 권한에 따라 다른 정보 반환
+    const isAdmin = ServerRoleUtils.hasAdminPermission(requestMember.serverRole);
+
+    if (isAdmin) {
+      // Admin/Owner: 상세 정보 포함
+      return activeMembers.map(member => ({
+        status: 'Active' as const,
+        serverRole: member.serverRole,
+        userInfo: {
+          userName: member.user.userName,
+          userEmail: member.user.userEmail,
+          profileImagePath: member.user.profileImagePath,
+        },
+      }));
+    } else {
+      // Member: 기본 정보만
+      return activeMembers.map(member => ({
+        userInfo: {
+          userName: member.user.userName,
+          userEmail: member.user.userEmail,
+          profileImagePath: member.user.profileImagePath,
+        },
+      }));
+    }
   }
 }

--- a/exbackend/src/domain/server/services/server-invitation.service.ts
+++ b/exbackend/src/domain/server/services/server-invitation.service.ts
@@ -8,6 +8,7 @@ import { ServerMember } from '../entities/server-member.entity';
 import { User } from '../../user/entities/user.entity';
 import { UserService } from '../../user/services/user.service';
 import { ServerRoleUtils, ServerRoleType } from '../../../common/enums/member-role.enum';
+import { MemberStatus, ServerMemberStatus, MemberStatusUtils } from '../../../common/enums/member-status.enum';
 import { Project } from '../../project/entities/project.entity';
 import { Channel } from '../../text-channel/entities/channel.entity';
 
@@ -52,7 +53,7 @@ export interface ServerMemberInfoDto {
 }
 
 export interface ServerMemberDetailDto extends ServerMemberInfoDto {
-  status: 'Active' | 'Inactive' | 'Banned';
+  status: MemberStatus;
   serverRole: ServerRoleType;
 }
 
@@ -617,7 +618,7 @@ export class ServerInvitationService {
     if (isAdmin) {
       // Admin/Owner: 상세 정보 포함
       return activeMembers.map(member => ({
-        status: 'Active' as const,
+        status: MemberStatusUtils.serverToMemberStatus(member.status as ServerMemberStatus),
         serverRole: member.serverRole,
         userInfo: {
           userName: member.user.userName,


### PR DESCRIPTION
# 🐿️ Merge Requests
## 🪵 작업 브랜치
---
> feature/#42-view-server-member

<br/>

## 🥔 작업 내용
---

- 서버 멤버목록 조회기능 추가
  - 요청하는 유저가 owner | admin 이면 status와 role 정보도 함께 반환


<br/>

## 📸 스크린샷 or 영상
<img width="776" height="1016" alt="image" src="https://github.com/user-attachments/assets/3c88ee0f-2ef1-4092-a7c3-2f84acda3347" />

---


## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>