### PR TITLE
fix(#55): 멤버 조회 시 active, inactive, banned 상태 상관없이 모두 조회 가능하게 수정

### DIFF
--- a/exbackend/src/domain/project/services/project-invitation.service.ts
+++ b/exbackend/src/domain/project/services/project-invitation.service.ts
@@ -204,9 +204,9 @@ export class ProjectInvitationService {
       throw new ForbiddenException('Only project members can view member list');
     }
 
-    // 3. 활성 멤버 목록 조회
+    // 3. 모든 멤버 목록 조회 (모든 상태)
     const projectMembers = await this.projectMemberRepository.find({
-      where: { projectPk, pStatus: 'Active' },
+      where: { projectPk },
       relations: ['user'],
       order: { projectMemberPk: 'ASC' },
     });

--- a/exbackend/src/domain/server/services/server-invitation.service.ts
+++ b/exbackend/src/domain/server/services/server-invitation.service.ts
@@ -413,7 +413,7 @@ export class ServerInvitationService {
     };
   }
 
-  // 서버의 활성 멤버 목록 조회 (Approved 상태만)
+  // 서버 멤버 목록 조회 (모든 상태)
   async getActiveServerMembers(serverPk: number, requestUserPk: number): Promise<PendingMemberDto[]> {
     // 1. 서버 존재 확인
     const server = await this.serverRepository.findOne({
@@ -437,14 +437,14 @@ export class ServerInvitationService {
       throw new ForbiddenException('Only server members can view member list');
     }
 
-    // 3. 활성 멤버 목록 조회 (Approved 상태만)
-    const activeMembers = await this.serverMemberRepository.find({
-      where: { serverPk, status: 'Approved' },
+    // 3. 모든 멤버 목록 조회 (모든 상태)
+    const allMembers = await this.serverMemberRepository.find({
+      where: { serverPk },
       relations: ['user'],
       order: { serverMemberPk: 'ASC' },
     });
 
-    return activeMembers.map(member => ({
+    return allMembers.map(member => ({
       status: member.status,
       userInfo: {
         user_pk: member.user.userPk,
@@ -605,9 +605,9 @@ export class ServerInvitationService {
       throw new ForbiddenException('Only server members can view member list');
     }
 
-    // 3. 승인된 멤버 목록 조회
-    const activeMembers = await this.serverMemberRepository.find({
-      where: { serverPk: server.serverPk, status: 'Approved' },
+    // 3. 모든 멤버 목록 조회 (모든 상태)
+    const allMembers = await this.serverMemberRepository.find({
+      where: { serverPk: server.serverPk },
       relations: ['user'],
       order: { serverMemberPk: 'ASC' },
     });
@@ -617,7 +617,7 @@ export class ServerInvitationService {
 
     if (isAdmin) {
       // Admin/Owner: 상세 정보 포함
-      return activeMembers.map(member => ({
+      return allMembers.map(member => ({
         status: MemberStatusUtils.serverToMemberStatus(member.status as ServerMemberStatus),
         serverRole: member.serverRole,
         userInfo: {
@@ -628,7 +628,7 @@ export class ServerInvitationService {
       }));
     } else {
       // Member: 기본 정보만
-      return activeMembers.map(member => ({
+      return allMembers.map(member => ({
         userInfo: {
           userName: member.user.userName,
           userEmail: member.user.userEmail,

--- a/exbackend/src/domain/text-channel/services/channel-invitation.service.ts
+++ b/exbackend/src/domain/text-channel/services/channel-invitation.service.ts
@@ -291,9 +291,9 @@ export class ChannelInvitationService {
       }
     }
 
-    // 3. 활성 멤버 목록 조회
+    // 3. 모든 멤버 목록 조회 (모든 상태)
     const channelMembers = await this.channelMemberRepository.find({
-      where: { channelPk, cStatus: 'Active' },
+      where: { channelPk },
       relations: ['user'],
       order: { channelMemberPk: 'ASC' },
     });


### PR DESCRIPTION
# 🐿️ Merge Requests
## 🪵 작업 브랜치
---
> fix/#55-get-all-status-member

<br/>

## 🥔 작업 내용
---

- 멤버 목록 조회 시 active 인 멤버만 response로 받음 -> status 상관 없이 모든 멤버를 response로 받음 

<br/>

## 📸 스크린샷 or 영상
(선택사항)
---


## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>