### PR TITLE
fix(#83): Message 엔티티 JPA 관계 매핑 및 채팅 파이프라인 버그 수정

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/channel/repository/ChannelRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/channel/repository/ChannelRepository.java
@@ -1,0 +1,7 @@
+package com.luminous.aurora.channel.repository;
+
+import com.luminous.aurora.channel.entity.Channel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChannelRepository extends JpaRepository<Channel, Integer> {
+}

--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatWebSocketController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatWebSocketController.java
@@ -3,6 +3,7 @@ package com.luminous.aurora.chat.controller;
 import com.luminous.aurora.auth.repository.UserRepository;
 import com.luminous.aurora.chat.dto.ChatMessage;
 import com.luminous.aurora.chat.dto.MessageRequest;
+import com.luminous.aurora.chat.entity.Message;
 import com.luminous.aurora.chat.service.ChatService;
 import com.luminous.aurora.jwt.JwtTokenProvider;
 import com.luminous.aurora.userstate.dto.UserStatusChangeRequest;
@@ -48,15 +49,10 @@ public class ChatWebSocketController {
                 throw new RuntimeException("JWT 토큰을 찾을 수 없습니다.");
 
             }
-            chatService.saveMessage(messageRequest, jwtToken);
-            ChatMessage chatMessage = ChatMessage.builder()
-                    .channelPk(messageRequest.getChannelPk())
-                    .dmRoomPk(messageRequest.getDmRoomPk())
-                    .userPk(extractUserPkFromToken(jwtToken))  // JWT에서 userPk 추출 필요
-                    .content(messageRequest.getContent())
-                    .messageType(messageRequest.getMessageType() != null ? messageRequest.getMessageType() : "TEXT")
-                    .createdAt(LocalDateTime.now())
-                    .build();
+
+            Message savedMessage = chatService.saveMessage(messageRequest, jwtToken);
+
+            ChatMessage chatMessage = chatService.convertToChatMessage(savedMessage);
 
             log.info("채널 메시지 전송 : channelPk = {}, userPk ={}", messageRequest.getChannelPk(), chatMessage.getUserPk());
 
@@ -84,16 +80,9 @@ public class ChatWebSocketController {
                 throw new RuntimeException("JWT 토큰을 찾을 수 없습니다.");
             }
             // 메시지 저장 및 chatMessage로 변환
-            chatService.saveMessage(messageRequest, jwtToken);
+            Message savedMessage = chatService.saveMessage(messageRequest, jwtToken);
 
-            ChatMessage chatMessage = ChatMessage.builder()
-                    .channelPk(messageRequest.getChannelPk())
-                    .dmRoomPk(messageRequest.getDmRoomPk())
-                    .userPk(extractUserPkFromToken(jwtToken))
-                    .content(messageRequest.getContent())
-                    .messageType(messageRequest.getMessageType() != null ? messageRequest.getMessageType() : "TEXT")
-                    .createdAt(LocalDateTime.now())
-                    .build();
+            ChatMessage chatMessage = chatService.convertToChatMessage(savedMessage);
 
             // DM 방의 멤버에게 메시지 전송
             String destination = "/topic/dm/" + messageRequest.getDmRoomPk();

--- a/spbackend/src/main/java/com/luminous/aurora/chat/entity/Message.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/entity/Message.java
@@ -1,6 +1,9 @@
 package com.luminous.aurora.chat.entity;
 
 
+import com.luminous.aurora.auth.entity.Users;
+import com.luminous.aurora.channel.entity.Channel;
+import com.luminous.aurora.dmroom.entity.DmRoom;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -19,9 +22,17 @@ public class Message {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long messagePk;
 
-    private Integer channelPk;
-    private Integer dmRoomPk;
-    private Integer userPk;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "channel_pk")
+    private Channel channelPk;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dm_room_pk")
+    private DmRoom dmRoomPk;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_pk", nullable = false)
+    private Users userPk;
 
     @Column(columnDefinition = "TEXT")
     private String content;

--- a/spbackend/src/main/java/com/luminous/aurora/chat/repository/MessageRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/repository/MessageRepository.java
@@ -11,23 +11,23 @@ import java.util.List;
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
     // 채널별 메시지 최신 메시지 조회 (처음 로드 시) 리미트 수 만큼 최초 로드시 보여줌, 일단 20개
-    @Query("SELECT m FROM Message m WHERE m.channelPk = :channelPk ORDER BY m.createdAt DESC LIMIT 20")
+    @Query("SELECT m FROM Message m WHERE m.channelPk.channelPk = :channelPk ORDER BY m.createdAt DESC LIMIT 20")
     List<Message> findLatestMessagesByChannelPk(@Param("channelPk") Integer channelPk);
 
     // 채널별 이전 메시지 조회 (스크롤 시)
-    @Query("SELECT m FROM Message m WHERE m.channelPk = :channelPk AND m.createdAt < :lastMessageTime ORDER BY m.createdAt DESC LIMIT 20")
+    @Query("SELECT m FROM Message m WHERE m.channelPk.channelPk = :channelPk AND m.createdAt < :lastMessageTime ORDER BY m.createdAt DESC LIMIT 20")
     List<Message> findOlderMessagesByChannelPk(@Param("channelPk") Integer channelPk,
-                                               @Param("lastMessageTime")LocalDateTime lastMessageTime);
+                                               @Param("lastMessageTime") LocalDateTime lastMessageTime);
 
     // DM 방별 최신 메시지 조회
-    @Query("SELECT m FROM Message m WHERE m.dmRoomPk = :dmRoomPk ORDER BY m.createdAt DESC LIMIT 20")
+    @Query("SELECT m FROM Message m WHERE m.dmRoomPk.dmRoomPk = :dmRoomPk ORDER BY m.createdAt DESC LIMIT 20")
     List<Message> findLatestMessagesByDmRoomPk(@Param("dmRoomPk") Integer dmRoomPk);
 
     // DM 방별 이전 메시지 조회
-    @Query("SELECT m FROM Message m WHERE m.dmRoomPk = :dmRoomPk AND m.createdAt < :lastMessageTime ORDER BY m.createdAt DESC LIMIT 20")
+    @Query("SELECT m FROM Message m WHERE m.dmRoomPk.dmRoomPk = :dmRoomPk AND m.createdAt < :lastMessageTime ORDER BY m.createdAt DESC LIMIT 20")
     List<Message> findOlderMessagesByDmRoomPk(@Param("dmRoomPk") Integer dmRoomPk,
-                                             @Param("lastMessageTime") LocalDateTime lastMessageTime);
+                                              @Param("lastMessageTime") LocalDateTime lastMessageTime);
 
     // 사용자가 쓴 메시지 조회
-    List<Message> findByUserPkOrderByCreatedAtDesc(Integer userPk);
+    List<Message> findByUserPk_UserPkOrderByCreatedAtDesc(Integer userPk);
 }

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface ChatService {
 
     // 메시지 저장
-    void saveMessage(MessageRequest request, String jwtToken);
+    Message saveMessage(MessageRequest request, String jwtToken);
 
     // 채널별 최신 메시지 조회 (최초 로드 시)
     List<MessageResponse> getLatestMessage(Integer channelPk, String jwtToken);

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
@@ -1,6 +1,9 @@
 package com.luminous.aurora.chat.service;
 
+import com.luminous.aurora.auth.entity.Users;
 import com.luminous.aurora.auth.repository.UserRepository;
+import com.luminous.aurora.channel.entity.Channel;
+import com.luminous.aurora.channel.repository.ChannelRepository;
 import com.luminous.aurora.chat.dto.ChatMessage;
 import com.luminous.aurora.chat.dto.MessageRequest;
 import com.luminous.aurora.chat.dto.MessageResponse;
@@ -10,6 +13,8 @@ import com.luminous.aurora.common.error.exception.BadRequestException;
 import com.luminous.aurora.common.error.exception.ForbiddenException;
 import com.luminous.aurora.common.error.exception.InternalServerErrorException;
 import com.luminous.aurora.common.error.exception.NotFoundException;
+import com.luminous.aurora.dmroom.entity.DmRoom;
+import com.luminous.aurora.dmroom.repository.DmRoomRepository;
 import com.luminous.aurora.jwt.JwtTokenProvider;
 import com.luminous.aurora.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -30,10 +35,29 @@ public class ChatServiceImpl implements ChatService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberService memberService;
+    private final ChannelRepository channelRepository;
+    private final DmRoomRepository dmRoomRepository;
 
+    /**
+     * 메시지를 DB에 저장
+     *
+     * @param request - 클라이언트가 보낸 메시지 정보 (channelPk/dmRoomPk, content, messageType)
+     * @param jwtToken - 사용자 인증 토큰 (누가 보냈는지 확인용)
+     *
+     * <p>
+     * 호출되는 곳:
+     * - ChatWebSocketController.sendChannelMessage() → 채널 채팅 시
+     * - ChatWebSocketController.sendDmMessage()      → DM 채팅 시
+     * <p>
+     * 처리 순서:
+     * 1. JWT에서 userPk 추출
+     * 2. 채널/DM방 접근 권한 검증
+     * 3. Channel, DmRoom, Users 엔티티 조회
+     * 4. Message 엔티티 생성 및 DB 저장
+     */
     @Override
     @Transactional
-    public void saveMessage(MessageRequest request, String jwtToken) {
+    public Message saveMessage(MessageRequest request, String jwtToken) {
         try {
             Integer userPk = getUserPkFromToken(jwtToken);
 
@@ -47,17 +71,24 @@ public class ChatServiceImpl implements ChatService {
                 validateDmRoomAccess(request.getDmRoomPk(), userPk);
             }
 
-            Message message = Message.builder()
-                    .channelPk(request.getChannelPk())
-                    .dmRoomPk(request.getDmRoomPk())
-                    .userPk(userPk)
-                    .content(request.getContent())
-                    .messageType(request.getMessageType() != null ? request.getMessageType() : "TEXT")
-                    .build();
+            Channel channel = null;
+            DmRoom dmRoom = null;
 
-            messageRepository.save(message);
+            if (request.getChannelPk() != null) {
+                channel = channelRepository.findById(request.getChannelPk()).orElseThrow(() -> new NotFoundException("채널을 찾을 수 없습니다."));
+            }
+            if (request.getDmRoomPk() != null) {
+                dmRoom = dmRoomRepository.findById(request.getDmRoomPk()).orElseThrow(() -> new NotFoundException("DM방을 찾을 수 없습니다."));
+            }
+            Users user = userRepository.findById(userPk).orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+
+            Message message = Message.builder().channelPk(channel).dmRoomPk(dmRoom).userPk(user).content(request.getContent()).messageType(request.getMessageType() != null ? request.getMessageType() : "TEXT").build();
+
+            Message savedMessage = messageRepository.save(message);
 
             log.info("메세지 저장: channelPk = {}, userPk = {}", request.getChannelPk(), userPk);
+
+            return savedMessage;
         } catch (ForbiddenException | NotFoundException e) {
             throw e;
         } catch (Exception e) {
@@ -66,6 +97,24 @@ public class ChatServiceImpl implements ChatService {
         }
     }
 
+    /**
+     * 채널의 최신 메시지 20개 조회 (처음 채널 입장 시)
+     *
+     * @param channelPk - 조회할 채널 PK
+     * @param jwtToken - 사용자 인증 토큰
+     * @return List<MessageResponse> - 메시지 목록 (최신순, 최대 20개)
+     * <p>
+     * 호출되는 곳:
+     * - ChatController (REST API) → GET /api/jv/chat/channel/{channelPk}/messages
+     * <p>
+     * 처리 순서:
+     * 1. JWT에서 userPk 추출
+     * 2. 채널 접근 권한 검증
+     * 3. MessageRepository에서 최신 20개 조회
+     * 4. Message → MessageResponse DTO 변환
+     * <p>
+     * 사용 시점: 사용자가 채널에 처음 들어갈 때
+     */
     @Override
     public List<MessageResponse> getLatestMessage(Integer channelPk, String jwtToken) {
         try {
@@ -74,9 +123,7 @@ public class ChatServiceImpl implements ChatService {
 
             List<Message> messages = messageRepository.findLatestMessagesByChannelPk(channelPk);
 
-            return messages.stream()
-                    .map(this::convertToMessageResponse)
-                    .collect(Collectors.toList());
+            return messages.stream().map(this::convertToMessageResponse).collect(Collectors.toList());
         } catch (ForbiddenException | NotFoundException e) {
             throw e;
         } catch (Exception e) {
@@ -85,6 +132,25 @@ public class ChatServiceImpl implements ChatService {
         }
     }
 
+    /**
+     * 채널의 이전 메시지 20개 조회 (스크롤 위로 올릴 때)
+     *
+     * @param channelPk - 조회할 채널 PK
+     * @param lastMessageTime - 현재 화면에서 가장 오래된 메시지의 시간
+     * @param jwtToken - 사용자 인증 토큰
+     * @return List<MessageResponse> - 이전 메시지 목록 (최대 20개)
+     * <p>
+     * 호출되는 곳:
+     * - ChatController (REST API) → GET /api/jv/chat/channel/{channelPk}/messages/older
+     * <p>
+     * 처리 순서:
+     * 1. JWT에서 userPk 추출
+     * 2. 채널 접근 권한 검증
+     * 3. lastMessageTime 이전의 메시지 20개 조회
+     * 4. Message → MessageResponse DTO 변환
+     * <p>
+     * 사용 시점: 사용자가 채팅창을 위로 스크롤할 때 (무한 스크롤)
+     */
     @Override
     public List<MessageResponse> getOlderMessage(Integer channelPk, LocalDateTime lastMessageTime, String jwtToken) {
         try {
@@ -92,9 +158,7 @@ public class ChatServiceImpl implements ChatService {
             validateChannelAccess(channelPk, userPk);
 
             List<Message> messages = messageRepository.findOlderMessagesByChannelPk(channelPk, lastMessageTime);
-            return messages.stream()
-                    .map(this::convertToMessageResponse)
-                    .collect(Collectors.toList());
+            return messages.stream().map(this::convertToMessageResponse).collect(Collectors.toList());
         } catch (ForbiddenException | NotFoundException e) {
             throw e;
         } catch (Exception e) {
@@ -103,6 +167,18 @@ public class ChatServiceImpl implements ChatService {
         }
     }
 
+    /**
+     * DM방의 최신 메시지 20개 조회 (처음 DM방 입장 시)
+     *
+     * @param dmRoomPk - 조회할 DM방 PK
+     * @param jwtToken - 사용자 인증 토큰
+     * @return List<MessageResponse> - 메시지 목록 (최신순, 최대 20개)
+     * <p>
+     * 호출되는 곳:
+     * - ChatController (REST API) → GET /api/jv/chat/dm/{dmRoomPk}/messages
+     * <p>
+     * 사용 시점: 사용자가 DM방에 처음 들어갈 때
+     */
     @Override
     public List<MessageResponse> getLatestDmMessage(Integer dmRoomPk, String jwtToken) {
         try {
@@ -110,9 +186,7 @@ public class ChatServiceImpl implements ChatService {
             validateDmRoomAccess(dmRoomPk, userPk);
 
             List<Message> messages = messageRepository.findLatestMessagesByDmRoomPk(dmRoomPk);
-            return messages.stream()
-                    .map(this::convertToMessageResponse)
-                    .collect(Collectors.toList());
+            return messages.stream().map(this::convertToMessageResponse).collect(Collectors.toList());
         } catch (ForbiddenException | NotFoundException e) {
             throw e;
         } catch (Exception e) {
@@ -121,6 +195,19 @@ public class ChatServiceImpl implements ChatService {
         }
     }
 
+    /**
+     * DM방의 이전 메시지 20개 조회 (스크롤 위로 올릴 때)
+     *
+     * @param dmRoomPk - 조회할 DM방 PK
+     * @param lastMessageTime - 현재 화면에서 가장 오래된 메시지의 시간
+     * @param jwtToken - 사용자 인증 토큰
+     * @return List<MessageResponse> - 이전 메시지 목록 (최대 20개)
+     * <p>
+     * 호출되는 곳:
+     * - ChatController (REST API) → GET /api/jv/chat/dm/{dmRoomPk}/messages/older
+     * <p>
+     * 사용 시점: 사용자가 DM 채팅창을 위로 스크롤할 때
+     */
     @Override
     public List<MessageResponse> getOlderDmMessage(Integer dmRoomPk, LocalDateTime lastMessageTime, String jwtToken) {
         try {
@@ -128,9 +215,7 @@ public class ChatServiceImpl implements ChatService {
             validateDmRoomAccess(dmRoomPk, userPk);
 
             List<Message> messages = messageRepository.findOlderMessagesByDmRoomPk(dmRoomPk, lastMessageTime);
-            return messages.stream()
-                    .map(this::convertToMessageResponse)
-                    .collect(Collectors.toList());
+            return messages.stream().map(this::convertToMessageResponse).collect(Collectors.toList());
         } catch (ForbiddenException | NotFoundException e) {
             throw e;
         } catch (Exception e) {
@@ -139,20 +224,38 @@ public class ChatServiceImpl implements ChatService {
         }
     }
 
-
+    /**
+     * Message 엔티티 → ChatMessage DTO 변환 (WebSocket 응답용)
+     *
+     * @param message - DB에서 조회한 Message 엔티티
+     * @return ChatMessage - WebSocket으로 클라이언트에게 전송할 DTO
+     * <p>
+     * 호출되는 곳:
+     * - ChatWebSocketController
+     * <p>
+     * 변환 내용:
+     * - message.getChannelPk() (Channel 엔티티) → channelPk (Integer)
+     * - message.getDmRoomPk() (DmRoom 엔티티)   → dmRoomPk (Integer)
+     * - message.getUserPk() (Users 엔티티)      → userPk (Integer), userName (String)
+     * <p>
+     * 용도: 실시간 채팅 메시지를 다른 사용자들에게 브로드캐스트할 때
+     * <p>
+     * ChatMessage DTO 구조:
+     * {
+     * "messagePk": 123,
+     * "channelPk": 1,
+     * "dmRoomPk": null,
+     * "userPk": 5,
+     * "userName": "홍길동",    ← REST API와 다르게 userName 포함!
+     * "content": "안녕하세요",
+     * "messageType": "TEXT",
+     * "createdAt": "2025-01-20T10:30:00"
+     * }
+     */
     @Override
     public ChatMessage convertToChatMessage(Message message) {
         try {
-            return ChatMessage.builder()
-                    .messagePk(message.getMessagePk())
-                    .channelPk(message.getChannelPk())
-                    .dmRoomPk(message.getDmRoomPk())
-                    .userPk(message.getUserPk())
-                    .userName(getUserNameByUserPk(message.getUserPk()))
-                    .content(message.getContent())
-                    .createdAt(message.getCreatedAt())
-                    .messageType(message.getMessageType())
-                    .build();
+            return ChatMessage.builder().messagePk(message.getMessagePk()).channelPk(message.getChannelPk() != null ? message.getChannelPk().getChannelPk() : null).dmRoomPk(message.getDmRoomPk() != null ? message.getDmRoomPk().getDmRoomPk() : null).userPk(message.getUserPk().getUserPk()).userName(message.getUserPk().getUserName()).content(message.getContent()).createdAt(message.getCreatedAt()).messageType(message.getMessageType()).build();
         } catch (NotFoundException | BadRequestException e) {
             throw e;
         } catch (Exception e) {
@@ -161,20 +264,36 @@ public class ChatServiceImpl implements ChatService {
         }
     }
 
-    // Message 엔티티를 MessageResponse로 변환
+    /**
+     * Message 엔티티 → MessageResponse DTO 변환 (REST API 응답용)
+     *
+     * @param message - DB에서 조회한 Message 엔티티
+     * @return MessageResponse - REST API로 클라이언트에게 전송할 DTO
+     * <p>
+     * 호출되는 곳:
+     * - getLatestMessage()
+     * - getOlderMessage()
+     * - getLatestDmMessage()
+     * - getOlderDmMessage()
+     * <p>
+     * 용도: 채널/DM방 입장 시 기존 메시지 목록 조회
+     * <p>
+     * MessageResponse DTO 구조: (ChatMessage와 동일)
+     * {
+     * "messagePk": 123,
+     * "channelPk": 1,
+     * "dmRoomPk": null,
+     * "userPk": 5,
+     * "userName": "홍길동",
+     * "content": "안녕하세요",
+     * "messageType": "TEXT",
+     * "createdAt": "2025-01-20T10:30:00"
+     * }
+     */
     @Override
     public MessageResponse convertToMessageResponse(Message message) {
         try {
-            return MessageResponse.builder()
-                    .messagePk(message.getMessagePk())
-                    .channelPk(message.getChannelPk())
-                    .dmRoomPk(message.getDmRoomPk())
-                    .userPk(message.getUserPk())
-                    .userName(getUserNameByUserPk(message.getUserPk()))
-                    .content(message.getContent())
-                    .createdAt(message.getCreatedAt())
-                    .messageType(message.getMessageType())
-                    .build();
+            return MessageResponse.builder().messagePk(message.getMessagePk()).channelPk(message.getChannelPk() != null ? message.getChannelPk().getChannelPk() : null).dmRoomPk(message.getDmRoomPk() != null ? message.getDmRoomPk().getDmRoomPk() : null).userPk(message.getUserPk().getUserPk()).userName(message.getUserPk().getUserName()).content(message.getContent()).createdAt(message.getCreatedAt()).messageType(message.getMessageType()).build();
         } catch (NotFoundException | BadRequestException e) {
             throw e;
         } catch (Exception e) {
@@ -183,32 +302,52 @@ public class ChatServiceImpl implements ChatService {
         }
     }
 
-    // jwt 토큰에서 userPk 추출
+    /**
+     이 아래는 Private 유틸 함수
+     */
+
+    /**
+     * JWT 토큰에서 userPk 추출
+     *
+     * @param jwtToken - JWT 토큰 문자열
+     * @return Integer - 사용자 PK
+     * <p>
+     * 처리 순서:
+     * 1. JwtTokenProvider로 토큰에서 userEmail 추출
+     * 2. UserRepository에서 userEmail로 userPk 조회
+     */
     private Integer getUserPkFromToken(String jwtToken) {
         String userEmail = jwtTokenProvider.getUserEmailFromToken(jwtToken);
-        return userRepository.findUserPkByUserEmail(userEmail)
-                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+        return userRepository.findUserPkByUserEmail(userEmail).orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
     }
 
-    private String getUserNameByUserPk(Integer userPk) {
-        try {
-            return userRepository.findById(userPk)
-                    .map(user -> user.getUserName())
-                    .orElse("알 수 없는 사용자");
-        } catch (Exception e) {
-            log.error("사용자명 조회 실패: {}", e.getMessage());
-            return "알 수 없는 사용자";
-        }
-    }
 
-    // 채널 접근 권한 검증
+    /**
+     * 채널 접근 권한 검증
+     *
+     * @param channelPk - 접근하려는 채널 PK
+     * @param userPk - 접근하려는 사용자 PK
+     * @throws ForbiddenException - 권한 없으면 403 에러
+     * <p>
+     * 검증 방법:
+     * - ChannelMember 테이블에 (channelPk, userPk) 조합이 있는지 확인
+     */
     private void validateChannelAccess(Integer channelPk, Integer userPk) {
         if (!memberService.hasChannelAccess(channelPk, userPk)) {
             throw new ForbiddenException("해당 채널에 접근할 권한이 없습니다.");
         }
     }
 
-    // dm 방 접근 권한 검증
+    /**
+     * DM방 접근 권한 검증
+     *
+     * @param dmRoomPk - 접근하려는 DM방 PK
+     * @param userPk - 접근하려는 사용자 PK
+     * @throws ForbiddenException - 권한 없으면 403 에러
+     * <p>
+     * 검증 방법:
+     * - DmMember 테이블에 (dmRoomPk, userPk) 조합이 있는지 확인
+     */
     private void validateDmRoomAccess(Integer dmRoomPk, Integer userPk) {
         if (!memberService.hasDmRoomAccess(dmRoomPk, userPk)) {
             throw new ForbiddenException("해당 DM방에 접근할 권한이 없습니다.");

--- a/spbackend/src/main/java/com/luminous/aurora/dmroom/repository/DmRoomRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/dmroom/repository/DmRoomRepository.java
@@ -1,0 +1,7 @@
+package com.luminous.aurora.dmroom.repository;
+
+import com.luminous.aurora.dmroom.entity.DmRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DmRoomRepository extends JpaRepository<DmRoom, Integer> {
+}

--- a/spbackend/src/main/java/com/luminous/aurora/member/entity/ChannelMember.java
+++ b/spbackend/src/main/java/com/luminous/aurora/member/entity/ChannelMember.java
@@ -12,7 +12,7 @@ import lombok.*;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "channelmember")
+@Table(name = "channel_member")
 public class ChannelMember {
 
     @Id

--- a/spbackend/src/main/java/com/luminous/aurora/member/entity/DmMember.java
+++ b/spbackend/src/main/java/com/luminous/aurora/member/entity/DmMember.java
@@ -12,7 +12,7 @@ import lombok.*;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "dmmember")
+@Table(name = "dm_member")
 public class DmMember {
 
     @Id


### PR DESCRIPTION


# 🐿️ Merge Requests
## 🪵 작업 브랜치
---
> 83-fixsp-backend-code

<br/>

## 🥔 작업 내용
---

- Message 엔티티 JPA 관계 매핑 및 채팅 파이프라인 버그 수정
- Message 엔티티 Integer → 실제 엔티티(Channel, DmRoom, Users) 관계 매핑 수정
- MessageRepository JPQL 쿼리 엔티티 탐색 경로 수정
- ChatService saveMessage 반환 타입 void → Message 변경
- ChatWebSocketController에서 convertToChatMessage 사용하도록 수정
- ChannelRepository, DmRoomRepository 추가
- ChannelMember, DmMember 테이블명 매핑 수정

<br/>



## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>