### PR TITLE
83 fixsp backend code

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/auth/controller/AuthController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import com.luminous.aurora.auth.service.TokenService;
 import com.luminous.aurora.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +27,12 @@ public class AuthController {
     private final AuthService authService;
     private final TokenService tokenService;
     private final JwtTokenProvider jwtTokenProvider;
+
+    @Value("${cookie.secure}")
+    private boolean cookieSecure;
+
+    @Value("${cookie.same-site}")
+    private String cookieSameSite;
 
     @PostMapping("/signup")
     public ResponseEntity<String> signup(@RequestBody SignUpRequest request) {
@@ -45,16 +52,16 @@ public class AuthController {
         // HttpOnly 쿠키 설정 (XSS 방지)
         ResponseCookie accessCookie = ResponseCookie.from("access_token", tokens.getAccessToken())
                 .httpOnly(true)
-                .secure(false) // 개발 환경에서는 false (HTTP 허용), 프로덕션에서는 true(HTTPS만 허용)
-                .sameSite("Lax") // 개발 환경에서는 Lax , 프로덕션에서는 Strict, nginx 프록시로 같은 도메인 통일 시 변경
+                .secure(cookieSecure) // 개발 환경에서는 false (HTTP 허용), 프로덕션에서는 true(HTTPS만 허용) -> https에서만 쿠키를 전송한다는뜻. localhost는 http라 false
+                .sameSite(cookieSameSite) // 개발 환경에서는 Lax , 프로덕션에서는 Strict, nginx 프록시로 같은 도메인 통일 시 변경 -> 다른사이트에서 요청 시 쿠키를 보낼까? strict - no, lax - get은 허용 post는 x
                 .maxAge(Duration.ofHours(1))
                 .path("/")
                 .build();
 
         ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", tokens.getRefreshToken())
                 .httpOnly(true)
-                .secure(false)
-                .sameSite("Lax")
+                .secure(cookieSecure)
+                .sameSite(cookieSameSite)
                 .maxAge(Duration.ofDays(7))
                 .path("/")
                 .build();
@@ -82,16 +89,16 @@ public class AuthController {
         // 쿠키 삭제
         ResponseCookie accessCookie = ResponseCookie.from("access_token","")
                 .httpOnly(true)
-                .secure(false)
-                .sameSite("Lax")
+                .secure(cookieSecure)
+                .sameSite(cookieSameSite)
                 .maxAge(0) // 즉시 삭제
                 .path("/")
                 .build();
 
         ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", "")
                 .httpOnly(true)
-                .secure(false)
-                .sameSite("Lax")
+                .secure(cookieSecure)
+                .sameSite(cookieSameSite)
                 .maxAge(0)
                 .path("/")
                 .build();
@@ -122,8 +129,8 @@ public class AuthController {
         // 새로운 accesstoken 쿠키 설정
         ResponseCookie accessCookie = ResponseCookie.from("access_token", tokens.getAccessToken())
                 .httpOnly(true)
-                .secure(false)
-                .sameSite("Lax")
+                .secure(cookieSecure)
+                .sameSite(cookieSameSite)
                 .maxAge(Duration.ofHours(1))
                 .path("/")
                 .build();

--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatWebSocketController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatWebSocketController.java
@@ -100,6 +100,7 @@ public class ChatWebSocketController {
     private String extractJwtFromSession(SimpMessageHeaderAccessor headerAccessor) {
         return (String) headerAccessor.getSessionAttributes().get("jwt_token");
     }
+
     // JWT 토큰에서 userPk 추출
     private Integer extractUserPkFromToken(String jwtToken) {
         // JWT에서 userEmail 추출 후 userPk 조회
@@ -155,5 +156,43 @@ public class ChatWebSocketController {
         }
     }
 
+    /**
+     * 비활동 감지 (프론트에서 x분 비활동시 호출)
+     */
+    @MessageMapping("/userstate/away")
+    public void setAutoAway(SimpMessageHeaderAccessor headerAccessor) {
+        try {
+            String jwtToken = extractJwtFromSession(headerAccessor);
+            if (jwtToken == null) {
+                throw new RuntimeException("JWT 토큰을 찾을 수 없습니다.");
+            }
+            Integer userPk = extractUserPkFromToken(jwtToken);
+            userStateService.setUserAway(userPk);
+
+            log.info("자동 자리 비움 설정");
+        } catch (Exception e) {
+            log.error("자동 자리비움 설정 실패 : {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 활동 감지 (프론트에서 마우스/키보드 움직임 감지 시 호출)
+     */
+    @MessageMapping("/userstate/active")
+    public void setActive(SimpMessageHeaderAccessor headerAccessor) {
+        try {
+            String jwtToken = extractJwtFromSession(headerAccessor);
+            if (jwtToken == null) {
+                throw new RuntimeException("JWT 토큰을 찾을 수 없습니다.");
+            }
+
+            Integer userPk = extractUserPkFromToken(jwtToken);
+            userStateService.setUserOnline(userPk);
+
+            log.info("활동 재개");
+        } catch (Exception e) {
+            log.error("활동 재개 설정 실패 : {}", e.getMessage());
+        }
+    }
 
 }

--- a/spbackend/src/main/java/com/luminous/aurora/chat/repository/MessageRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/repository/MessageRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
@@ -30,4 +31,21 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
 
     // 사용자가 쓴 메시지 조회
     List<Message> findByUserPk_UserPkOrderByCreatedAtDesc(Integer userPk);
+
+    // DM방의 가장 최신 메시지 1개 조회(마지막 메시지 미리보기용)
+    @Query("SELECT m FROM Message m " +
+            "WHERE m.dmRoomPk.dmRoomPk = :dmRoomPk " +
+            "ORDER BY m.createdAt DESC LIMIT 1")
+    Optional<Message> findLatestMessageInDmRoom(@Param("dmRoomPk") Integer dmRoomPk);
+
+    // 읽지 않은 메시지 개수 (내가 보낸것 제외)
+    @Query("SELECT COUNT(m) FROM Message m " +
+            "WHERE m.dmRoomPk.dmRoomPk = :dmRoomPk " +
+            "AND m.messagePk > :lastReadMessagePk " +
+            "AND m.userPk.userPk != :myUserPk")
+    Long countUnreadMessages(
+            @Param("dmRoomPk") Integer DmRoomPk,
+            @Param("lastReadMessagePk") Long lastReadMessagePk,
+            @Param("myUserPk") Integer myUserPk
+    );
 }

--- a/spbackend/src/main/java/com/luminous/aurora/member/dto/DmRoomResponse.java
+++ b/spbackend/src/main/java/com/luminous/aurora/member/dto/DmRoomResponse.java
@@ -1,0 +1,23 @@
+package com.luminous.aurora.member.dto;
+
+import com.luminous.aurora.userstate.entity.UserStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DmRoomResponse {
+    private Integer dmRoomPk;
+    private String otherUserEmail; // 상대방 email
+    private String otherUserName; // 상대방 이름
+    private String otherProfileImage; // 상대 프로필 이미지
+    private Boolean isMute; // 차단 여부 node.js 에서 관리하는데 현재는 기능 없는걸로앎
+    private UserStatus userStatus; // 상대방 실시간 상태 (Online, Away, DND, Offline)
+    private String lastMessageContent; // 마지막 메시지 미리보기
+    private LocalDateTime lastMessageTime; // 마지막 메시지 시간
+    private Integer unreadCount; // 읽지 않은 메시지 수
+}

--- a/spbackend/src/main/java/com/luminous/aurora/member/repository/DmMemberRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/member/repository/DmMemberRepository.java
@@ -18,10 +18,13 @@ public interface DmMemberRepository extends JpaRepository<DmMember, Integer> {
     // DM방 멤버 존재 여부 확인
     boolean existsByDmRoom_DmRoomPkAndUser_UserPk(Integer dmRoomPk, Integer userPk);
 
-    // DM 멤버 조회 (해당 DM룸의 가장 최근 메시지 시간으로 정렬)
+    // 내가 참여한 DM 방 목록 조회 (최신 메시지순 )
     @Query("SELECT dm FROM DmMember dm " +
-           "LEFT JOIN Message m ON dm.dmRoom = m.dmRoomPk " +
-           "WHERE dm.dmRoom.dmRoomPk = :dmRoomPk " +
-           "ORDER BY m.createdAt DESC")
-    List<DmMember> findByDmRoom_DmRoomPkOrderByLastMessageTimeDesc(@Param("dmRoomPk") Integer dmRoomPk);
+            "WHERE dm.user.userPk = :userPk " +
+            "ORDER BY (SELECT MAX(m.createdAt) FROM Message m " +
+            "WHERE m.dmRoomPk = dm.dmRoom) DESC NULLS LAST")
+    List<DmMember> findMyDmRoomsOrderByLastMessage(@Param("userPk") Integer userPk);
+
+    // DM 방의 모든 멤버 조회
+    List<DmMember> findByDmRoom_DmRoomPk(Integer dmRoomPk);
 }

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
@@ -2,7 +2,7 @@ package com.luminous.aurora.userstate.controller;
 
 import com.luminous.aurora.auth.repository.UserRepository;
 import com.luminous.aurora.jwt.JwtTokenProvider;
-import com.luminous.aurora.member.entity.DmMember;
+import com.luminous.aurora.member.dto.DmRoomResponse;
 import com.luminous.aurora.project.entity.ProjectMember;
 import com.luminous.aurora.userstate.dto.*;
 import com.luminous.aurora.userstate.entity.UserStatus;
@@ -20,7 +20,7 @@ import java.util.List;
 
 @Slf4j
 @RestController
-@RequestMapping("jv/api/userstate")
+@RequestMapping("/api/jv/userstate")
 @RequiredArgsConstructor
 public class UserStateController {
 
@@ -88,11 +88,11 @@ public class UserStateController {
 
     // DM 멤버 조회 (최신순)
 
-    @GetMapping("/dm/{dmRoomPk}/members")
-    public ResponseEntity<List<DmMember>> getDmMembers(
-            @PathVariable Integer dmRoomPk) {
-        List<DmMember> members = userStateService.getDmMembers(dmRoomPk);
-        return ResponseEntity.ok(members);
+    @GetMapping("/dm/rooms")
+    public ResponseEntity<List<DmRoomResponse>> getMyDmRooms(HttpServletRequest request) {
+        Integer userPk = extractUserPkFromRequest(request);
+        List<DmRoomResponse> dmRooms = userStateService.getDmRoomsWithStatus(userPk);
+        return ResponseEntity.ok(dmRooms);
     }
 
 

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/repository/UserStateRedisRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/repository/UserStateRedisRepository.java
@@ -7,9 +7,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 
 @Slf4j

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/repository/UserStateRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/repository/UserStateRepository.java
@@ -1,12 +1,9 @@
 package com.luminous.aurora.userstate.repository;
 
-import com.luminous.aurora.member.entity.DmMember;
-import com.luminous.aurora.project.entity.ProjectMember;
 import com.luminous.aurora.userstate.entity.UserState;
 import com.luminous.aurora.userstate.entity.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+
 
 import java.util.List;
 import java.util.Optional;

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateService.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateService.java
@@ -1,12 +1,11 @@
 package com.luminous.aurora.userstate.service;
 
-import com.luminous.aurora.member.entity.DmMember;
+import com.luminous.aurora.member.dto.DmRoomResponse;
 import com.luminous.aurora.project.entity.ProjectMember;
-import com.luminous.aurora.userstate.entity.UserState;
 import com.luminous.aurora.userstate.entity.UserStatus;
 
 import java.util.List;
-import java.util.Optional;
+
 
 public interface UserStateService {
 
@@ -18,6 +17,9 @@ public interface UserStateService {
 
     // 사용자 온라인 상태 설정(자동)
     void setUserOnline(Integer userPk);
+
+    // 사용자 자리비움 상태 설정 (자동, 비활동 감지시)
+    void setUserAway(Integer userPk);
 
     // 사용자 오프라인 상태 설정(자동)
     void setUserOffline(Integer userPk);
@@ -31,7 +33,7 @@ public interface UserStateService {
     List<ProjectMember> getProjectMembersWithStatus(Integer projectPk);
 
     // ===== DM 멤버 조회 ========
-    // DM멤버 조회
-    List<DmMember> getDmMembers(Integer dmRoomPk);
+    // DM멤버 조회 (최신 메시지순 + 상태 + unreadCount)
+    List<DmRoomResponse> getDmRoomsWithStatus(Integer userPk);
 
 }

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateServiceImpl.java
@@ -1,9 +1,12 @@
 package com.luminous.aurora.userstate.service;
 
+import com.luminous.aurora.chat.entity.Message;
+import com.luminous.aurora.chat.repository.MessageRepository;
 import com.luminous.aurora.common.error.exception.BadRequestException;
 import com.luminous.aurora.common.error.exception.ForbiddenException;
 import com.luminous.aurora.common.error.exception.InternalServerErrorException;
 import com.luminous.aurora.common.error.exception.NotFoundException;
+import com.luminous.aurora.member.dto.DmRoomResponse;
 import com.luminous.aurora.member.entity.DmMember;
 import com.luminous.aurora.member.repository.DmMemberRepository;
 import com.luminous.aurora.project.entity.ProjectMember;
@@ -31,6 +34,7 @@ public class UserStateServiceImpl implements UserStateService {
     private final UserStateRedisRepository redisRepository;
     private final ProjectMemberRepository projectMemberRepository;
     private final DmMemberRepository dmMemberRepository;
+    private final MessageRepository messageRepository;
 
     // ====기본 상태 관리 ====
     @Override
@@ -38,18 +42,27 @@ public class UserStateServiceImpl implements UserStateService {
         try {
             // 1. 의도적 설정 상태 조회 (DB)
             Optional<UserState> userState = userStateRepository.findByUserPk(userPk);
-            if (userState.isPresent() && userState.get().getStatus() != UserStatus.OFFLINE) {
-                return userState.get().getStatus();
+            if (userState.isPresent()) {
+                UserStatus dbStatus = userState.get().getStatus();
+
+                // ONLINE 설정 시만 redis 확인
+                if (dbStatus == UserStatus.ONLINE) {
+                    Optional<UserStatus> redisStatus = redisRepository.getUserStatus(userPk);
+
+                    if (redisStatus.isPresent()) {
+                        return redisStatus.get(); // ONLINE 또는 AWAY
+                    } else {
+                        return UserStatus.OFFLINE; // 연결 끊김
+                    }
+                }
+                // AWAY, DND, OFFLINE 바로 반환 (명시적 설정 우선)
+                return dbStatus;
             }
 
-            // 2. 자동상태 조회 (Redis)
+            // 2. DB 없으면 Redis 자동 상태 확인자동상태 조회
             Optional<UserStatus> redisStatus = redisRepository.getUserStatus(userPk);
-            if (redisStatus.isPresent()) {
-                return redisStatus.get();
-            }
+            return redisStatus.orElse(UserStatus.OFFLINE);
 
-            // 3. 기본값
-            return UserStatus.OFFLINE;
         } catch (Exception e) {
             log.error("사용자 상태 조회 실패 : {}", e.getMessage());
             // 상태 조회 실패 시 안전하게 OFFLINE 반환
@@ -87,6 +100,17 @@ public class UserStateServiceImpl implements UserStateService {
         } catch (Exception e) {
             log.error("사용자 온라인 설정 실패 : {}", e.getMessage());
             // Redis는 캐시이므로 오류가 발생해도 치명적이지 않기 때문에 로그만 기록하고 진행
+        }
+    }
+
+    // 자동 자리비움 설정
+    @Override
+    public void setUserAway(Integer userPk) {
+        try {
+            redisRepository.saveUserStatus(userPk, UserStatus.AWAY, 30);
+            log.debug("사용자 자동 자리 비움 설정(Redis) : userPk = {}", userPk);
+        } catch (Exception e) {
+            log.error("사용자 자동 자리비움 설정 실패 : {}", e.getMessage());
         }
     }
 
@@ -153,18 +177,68 @@ public class UserStateServiceImpl implements UserStateService {
     }
 
 
-    // ========== DM 멤버 조회 ==========
+    // ========== DM 방 조회 ==========
 
     @Override
-    public List<DmMember> getDmMembers(Integer dmRoomPk) {
+    public List<DmRoomResponse> getDmRoomsWithStatus(Integer userPk) {
         try {
-            // DM 멤버 조회 (최신순)
-            return dmMemberRepository.findByDmRoom_DmRoomPkOrderByLastMessageTimeDesc(dmRoomPk);
-        } catch (NotFoundException | BadRequestException | ForbiddenException e) {
-            throw e;
+            // 1. 내 DM 멤버 조회 (최신 메시지순)
+            List<DmMember> myDmMembers = dmMemberRepository.findMyDmRoomsOrderByLastMessage(userPk);
+
+            // 2. 각 DM 방 정보 조합
+            return myDmMembers.stream()
+                    .map(myDmMember -> {
+                        Integer dmRoomPk = myDmMember.getDmRoom().getDmRoomPk();
+
+                        // 2-1. 상대방 찾기
+                        List<DmMember> allMembers = dmMemberRepository.findByDmRoom_DmRoomPk(dmRoomPk);
+                        DmMember otherMember = allMembers.stream()
+                                .filter(member -> !member.getUser().getUserPk().equals(userPk))
+                                .findFirst()
+                                .orElse(null);
+
+                        if (otherMember == null) {
+                            return null;
+                        }
+
+                        // 2-2 상대방 상태 조회
+                        Integer otherUserPk = otherMember.getUser().getUserPk();
+                        UserStatus otherUserStatus = getUserStatus(otherUserPk);
+
+                        // 2-3 마지막 메시지 조회
+                        Message lastMessage = messageRepository
+                                .findLatestMessageInDmRoom(dmRoomPk)
+                                .orElse(null);
+
+                        // 2-4 읽지 않은 메시지 개수
+                        Integer unreadCount = 0;
+                        if (myDmMember.getLastReadMessage() != null) {
+                            Long count = messageRepository.countUnreadMessages(
+                                    dmRoomPk,
+                                    myDmMember.getLastReadMessage().getMessagePk(),
+                                    userPk
+                            );
+                            unreadCount = count.intValue();
+                        }
+
+                        // 2-5 DTO 생성
+                        return DmRoomResponse.builder()
+                                .dmRoomPk(dmRoomPk)
+                                .otherUserEmail(otherMember.getUser().getUserEmail())
+                                .otherUserName(otherMember.getUser().getUserName())
+                                .otherProfileImage(otherMember.getUser().getProfileImagePath())
+                                .isMute(myDmMember.getIsMute())
+                                .userStatus(otherUserStatus)
+                                .lastMessageContent(lastMessage != null ? lastMessage.getContent() : null)
+                                .lastMessageTime(lastMessage != null ? lastMessage.getCreatedAt() : null)
+                                .unreadCount(unreadCount)
+                                .build();
+                    })
+                    .filter(response -> response!= null)
+                    .collect(Collectors.toList());
         } catch (Exception e) {
-            log.error("DM 멤버 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("DM 멤버 조회 중 서버 오류가 발생했습니다.: " + e.getMessage());
+            log.error("DM 목록 조회 실패 : {}", e.getMessage());
+            throw new InternalServerErrorException("DM 목록 조회 중 오류 발생 : " +e.getMessage());
         }
     }
 }

--- a/spbackend/src/main/resources/application.yml
+++ b/spbackend/src/main/resources/application.yml
@@ -48,3 +48,7 @@ logging:
     org.springframework.web: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+cookie:
+  secure: true
+  same-site: Strict


### PR DESCRIPTION
# 🐿️ Merge Requests
## 🪵 작업 브랜치
---
> 83 fixsp backend code

<br/>

## 🥔 작업 내용
---
 주요 기능
- 쿠키 보안 설정 환경 변수 분리 
  - AuthController 쿠키 설정 하드코딩 제거
  - application.yml에 cookie.secure, cookie.same-site 설정 추가
  - 개발(dev): secure=false, sameSite=Lax
  - 프로덕션: secure=true, sameSite=Strict
- DM 목록 조회 API 구현 (GET /jv/api/userstate/dm/rooms)
  - 최신 메시지순 자동 정렬
  - 마지막 메시지 미리보기
  - 읽지 않은 메시지 개수 표시
  - 상대방 실시간 상태 표시 (ONLINE/AWAY/DND/OFFLINE)
  - 보안을 위한 userPk 대신 email 사용
- 실시간 유저 상태 관리 시스템
  - DB(명시적 설정) + Redis(자동 상태) 이중 관리
  - 상태 우선순위 로직 구현
  - DB ONLINE 설정 시: Redis 확인 → ONLINE/AWAY/OFFLINE
  - DB AWAY/DND/OFFLINE 설정 시: 명시적 설정 우선
  - DB 없을 시: Redis 자동 상태 확인
- 자동 상태 변경 WebSocket 핸들러 추가
  - /app/userstate/away: 5분 비활동 시 자동 자리비움
  - /app/userstate/active: 활동 재개 시 자동 ONLINE 전환
  - Redis에만 저장 (TTL 30분)
 
상세 변경사항
- DmRoomResponse DTO 추가
  - userStatus: 상대방 실시간 상태
  - lastMessageContent: 마지막 메시지 미리보기
  - lastMessageTime: 마지막 메시지 시간
  - unreadCount: 읽지 않은 메시지 개수
- DmMemberRepository 쿼리 메서드 추가
  - findMyDmRoomsOrderByLastMessage(): 내 DM 목록 최신 메시지순 조회
  - findByDmRoom_DmRoomPk(): DM방의 모든 멤버 조회
- MessageRepository 쿼리 메서드 추가
  - findLatestMessageInDmRoom(): DM방의 최신 메시지 1개 조회
  - countUnreadMessages(): 읽지 않은 메시지 개수 계산
- UserStateServiceImpl 로직 구현
  - getUserStatus(): 상태 우선순위 로직 재작성
  - setUserAway(): 자동 자리비움 메서드 추가
  - getDmRoomsWithStatus(): DM 목록 조회 로직 구현
- UserStateController 엔드포인트 수정
  - /dm/rooms: 반환 타입을 DmRoomResponse로 변경
- ChatWebSocketController 핸들러 추가
  - /userstate/away: 자동 자리비움
  - /userstate/active: 자동 활동 재개

<br/>

## 📸 스크린샷 or 영상
(선택사항)
---


## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>