### PR TITLE
83-fixsp-backend-code

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/config/HttpHandshakeInterceptor.java
+++ b/spbackend/src/main/java/com/luminous/aurora/config/HttpHandshakeInterceptor.java
@@ -28,21 +28,32 @@ public class HttpHandshakeInterceptor implements HandshakeInterceptor {
             if (cookies != null) {
                 log.info("쿠키 개수: {}", cookies.length);
 
-                Arrays.stream(cookies)
+                boolean hasToken = Arrays.stream(cookies)
                         .filter(cookie -> "access_token".equals(cookie.getName()))
                         .findFirst()
-                        .ifPresent(cookie -> {
+                        .map(cookie -> {
                             attributes.put("jwt_token", cookie.getValue());
                             log.info("✅ JWT 토큰을 세션 속성에 저장: 완료");
-                        });
+                            return true; // 토큰 있으면 true 반환
+                        })
+                        .orElse(false);
+
+                if (hasToken) {
+                    log.info("🔐 핸드셰이크 완료, attributes: {}", attributes.keySet());
+                    return true;
+                } else {
+                    log.warn("access_token 쿠키가 없습니다. - 연결 거부");
+                    return false;
+                }
+
             } else {
                 log.warn("쿠키가 없습니다"); // ✅ 로그 추가
+                return false;
             }
         } else {
             log.warn(" ServletServerHttpRequest가 아닙니다: {}", request.getClass().getSimpleName());
+            return false;
         }
-        log.info("🔐 핸드셰이크 완료, attributes: {}", attributes.keySet());
-        return true;
     }
 
     @Override

--- a/spbackend/src/main/java/com/luminous/aurora/config/SecurityConfig.java
+++ b/spbackend/src/main/java/com/luminous/aurora/config/SecurityConfig.java
@@ -34,9 +34,9 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 안함 -> jwt 로그인 방식이기 때문
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/").permitAll() // 루트경로 허용
-                        .requestMatchers("/test.html").permitAll()
                         .requestMatchers("/api/jv/login","/api/jv/signup","/api/jv/refresh").permitAll() // 인증관련 api 전부 허용
-                        .requestMatchers("/ws/**").authenticated()
+                        .requestMatchers("/ws/info").permitAll() // 웹소켓 연결을 위한 SockJS 허용
+                        .requestMatchers("/ws/**").authenticated() // Websocket 연결은 인증
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
@@ -52,9 +52,7 @@ public class SecurityConfig {
                 "http://localhost:3000",      // Express 개발 서버
                 "http://localhost:8080",      // Spring Boot 개발 서버
                 "http://localhost:5173",      // React 개발 서버
-                "https://auro-ra.site",    // 프로덕션 서버
-                "http://127.0.0.1:5500"
-
+                "https://auro-ra.site"    // 프로덕션 서버
         ));
 
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));


### PR DESCRIPTION
네! PR 문서 작성해드리겠습니다.

---

# 🐿️ Merge Requests

## 🪵 작업 브랜치
---
> `83-fixsp-backend-code`

<br/>

## 🥔 작업 내용
---

### 🔒 WebSocket 보안 강화

- **WebSocket 핸드셰이크 JWT 인증 로직 개선**
  - JWT 토큰이 없는 WebSocket 연결 차단
  - 인증된 사용자만 WebSocket 연결 허용
  - 이중 보안 구조 구현 (Spring Security + HandshakeInterceptor)

### 📝 상세 변경사항

#### 1. `HttpHandshakeInterceptor.java` 수정
- **JWT 토큰 검증 로직 개선**
  - `ifPresent()` → `map() + orElse()` 패턴으로 변경
  - 토큰 존재 여부를 명확히 판단하여 `boolean` 반환
  - JWT 토큰이 있을 때만 `return true` (연결 허용)
  - JWT 토큰이 없으면 `return false` (연결 차단)
  
- **상세한 로그 추가**
  - 토큰 발견 시: "✅ JWT 토큰을 세션 속성에 저장: 완료"
  - 토큰 없음 시: "access_token 쿠키가 없습니다. - 연결 거부"
  - 쿠키 자체가 없을 시: "쿠키가 없습니다"

#### 2. `SecurityConfig.java` 수정
- **WebSocket 경로 보안 설정 세분화**
  - `/ws/info`: `permitAll()` - SockJS 정보 조회만 허용
  - `/ws/**`: `authenticated()` - 실제 WebSocket 연결은 JWT 인증 필요
  
- **기존 문제점**
  - 기존: `/ws/**` 전체가 `authenticated()` → SockJS `/ws/info` 요청도 차단되어 연결 불가
  - 수정: `/ws/info`만 `permitAll()` → SockJS가 정상적으로 서버 정보 조회 가능

### 🔐 보안 아키텍처

#### 이중 보안 구조
```
1단계: Spring Security (HTTP 레벨)
  - JwtAuthenticationFilter가 Cookie에서 JWT 추출 및 검증
  - 유효한 JWT → SecurityContext에 Authentication 저장
  - 무효한 JWT → 401 Unauthorized 반환

2단계: HandshakeInterceptor (WebSocket 레벨)
  - JWT를 WebSocket 세션 attributes에 저장
  - 메시지 핸들러에서 사용할 수 있도록 전달
  - JWT 없는 연결 차단
```

#### WebSocket 연결 흐름
```
클라이언트
    ↓
1. GET /ws/info (SockJS 정보 조회)
    → SecurityConfig: permitAll() ✅
    → 응답: 서버 정보 반환
    ↓
2. GET /ws (WebSocket 핸드셰이크)
    → SecurityConfig: authenticated() 
    → JwtAuthenticationFilter: JWT 검증
    → HttpHandshakeInterceptor: JWT 세션 저장
    → 연결 성공 ✅
    ↓
3. 메시지 송수신
    → ChatWebSocketController에서 세션의 JWT 사용
```

<br/>

## 📸 스크린샷 or 영상
---

### 예상 로그
```
# JWT 토큰 있는 경우
핸드셰이크 시작
쿠키 개수: 2
✅ JWT 토큰을 세션 속성에 저장: 완료
🔐 핸드셰이크 완료, attributes: [jwt_token]

# JWT 토큰 없는 경우
핸드셰이크 시작
쿠키 개수: 1
access_token 쿠키가 없습니다. - 연결 거부
```

<br/>

## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
  - [ ] JWT 토큰이 있는 경우 WebSocket 연결 성공
  - [ ] JWT 토큰이 없는 경우 WebSocket 연결 차단
  - [ ] SockJS `/ws/info` 요청 정상 동작
  - [ ] WebSocket 메시지 송수신 정상 동작
  
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
  - [ ] 커밋 메시지 컨벤션 준수
  - [ ] 코드 스타일 컨벤션 준수
  
- [ ] 보안이 제대로 적용되었는지 확인해주세요.
  - [ ] 인증되지 않은 사용자의 WebSocket 연결 차단
  - [ ] JWT 토큰 검증 로직 정상 작동
  - [ ] 로그를 통한 보안 이벤트 추적 가능

<br/>

## 🐛 수정된 버그
---
- WebSocket 핸드셰이크 시 JWT 검증 누락
- `/ws/**` 경로 전체 인증 요구로 인한 SockJS `/ws/info` 차단 문제

<br/>

## 📋 관련 이슈
---
- Related to #83

## 🔗 참고 자료
---
- [Spring WebSocket Security](https://docs.spring.io/spring-security/reference/servlet/integrations/websocket.html)
- [SockJS Protocol](https://github.com/sockjs/sockjs-protocol)

<br/>

---

이 PR 문서로 작성하시면 됩니다! 🚀