### PR TITLE
fix: 컨트롤러 예외 처리 GlobalExceptionHandler로 통일

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/auth/controller/AuthController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.luminous.aurora.auth.dto.SignUpRequest;
 import com.luminous.aurora.auth.dto.TokenResponse;
 import com.luminous.aurora.auth.service.AuthService;
 import com.luminous.aurora.auth.service.TokenService;
+import com.luminous.aurora.common.error.exception.UnauthorizedException;
 import com.luminous.aurora.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
@@ -74,14 +76,13 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(@CookieValue("access_token") String token) {
+    public ResponseEntity<String> logout(@CookieValue(value = "access_token", required = false) String token) {
         log.info("로그아웃 요청");
 
-        if (token == null) {
-            return ResponseEntity.badRequest().body("토큰이 없습니다.");
+        if (!StringUtils.hasText(token)) {
+            throw new UnauthorizedException("토큰이 없습니다.");
         }
 
-        try {
         // 토큰에서 userEmail 추출
         String userEmail = jwtTokenProvider.getUserEmailFromToken(token);
         authService.logout(userEmail);
@@ -107,23 +108,15 @@ public class AuthController {
                 .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
                 .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
                 .body("로그아웃이 완료되었습니다.");
-        } catch (Exception e) {
-            log.error("로그아웃 중 에러 발생 : {}", e.getMessage());
-            return ResponseEntity.badRequest().body("유효하지 않은 토큰입니다.");
-        }
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<TokenResponse> refreshToken(@CookieValue("refresh_token") String refreshToken) {
+    public ResponseEntity<TokenResponse> refreshToken(@CookieValue(value = "refresh_token", required = false) String refreshToken) {
         log.info("토큰 갱신 요청");
-        if (refreshToken == null ){
-            return ResponseEntity.badRequest().body(TokenResponse.builder()
-                    .accessToken("")
-                    .refreshToken("")
-                    .build());
+        if (!StringUtils.hasText(refreshToken) ){
+            throw new UnauthorizedException("Refresh Token이 없습니다.");
         }
 
-        try {
         TokenResponse tokens = tokenService.refreshToken(refreshToken);
 
         // 새로운 accesstoken 쿠키 설정
@@ -138,29 +131,15 @@ public class AuthController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
                 .body(tokens);
-        } catch (Exception e) {
-            log.error("토큰 갱신 중 에러 발생 : {}", e.getMessage());
-            return ResponseEntity.badRequest().body(TokenResponse.builder()
-                    .accessToken("")
-                    .refreshToken("")
-                    .build());
-        }
     }
 
     @GetMapping("/info")
     public ResponseEntity<AuthInfo> getUserInfo(@CookieValue("access_token") String token) {
         log.info("사용자 정보 조회 요청");
-
-        try {
             String userEmail = jwtTokenProvider.getUserEmailFromToken(token);
-
             AuthInfo userInfo = authService.getUserInfo(userEmail);
-
             return ResponseEntity.ok(userInfo);
-        } catch (Exception e) {
-            log.error("사용자 정보 조회 실패 : {}", e.getMessage());
-            return ResponseEntity.badRequest().build();
-        }
+
     }
 
 }

--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
@@ -22,34 +22,27 @@ public class ChatController {
 
     // 채널 메시지 저장
     @PostMapping("/channel")
-    public ResponseEntity<String> saveChannelMessage(@RequestBody MessageRequest request,
-                                                              @CookieValue("access_token") String jwtToken) {
-        try {
-            // 저장
-            chatService.saveMessage(request, jwtToken);
+    public ResponseEntity<String> saveChannelMessage(
+            @RequestBody MessageRequest request,
+            @CookieValue("access_token") String jwtToken) {
+        // 저장
+        chatService.saveMessage(request, jwtToken);
 
-            log.info("채널 메시지 저장 성공 : channelPk ={}, dmRoomPk = {}",
-                    request.getChannelPk(), request.getDmRoomPk());
-            return ResponseEntity.ok("메시지가 성공적으로 저장되었습니다.");
-        } catch (Exception e) {
-            log.error("채널 메시지 저장 실패 :{}", e.getMessage());
-            return ResponseEntity.badRequest().build();
-        }
+        log.info("채널 메시지 저장 성공 : channelPk ={}, dmRoomPk = {}",
+                request.getChannelPk(), request.getDmRoomPk());
+        return ResponseEntity.ok("메시지가 성공적으로 저장되었습니다.");
+
     }
+
     // 채널 최신 메시지 조회 (최초 로드)
     @GetMapping("/channel/{channelPk}/messages")
     public ResponseEntity<List<MessageResponse>> getLatestChannelMessages(
             @PathVariable Integer channelPk,
             @CookieValue("access_token") String jwtToken) {
-        try {
             List<MessageResponse> messages = chatService.getLatestMessage(channelPk, jwtToken);
             log.info("채널 최신 메시지 조회 성공: channelPk={}, messageCount={}",
                     channelPk, messages.size());
             return ResponseEntity.ok(messages);
-        } catch (Exception e) {
-            log.error("채널 최신 메시지 조회 실패: {}", e.getMessage());
-            return ResponseEntity.badRequest().build();
-        }
     }
 
     // 채널 이전 메시지 조회 (무한스크롤)
@@ -58,15 +51,10 @@ public class ChatController {
             @PathVariable Integer channelPk,
             @RequestParam LocalDateTime lastMessageTime,
             @CookieValue("access_token") String jwtToken) {
-        try {
             List<MessageResponse> messages = chatService.getOlderMessage(channelPk, lastMessageTime, jwtToken);
             log.info("채널 이전 메시지 조회 성공: channelPk={}, messageCount={}, lastMessageTime={}",
                     channelPk, messages.size(), lastMessageTime);
             return ResponseEntity.ok(messages);
-        } catch (Exception e) {
-            log.error("채널 이전 메시지 조회 실패: {}", e.getMessage());
-            return ResponseEntity.badRequest().build();
-        }
     }
 
     // DM방 최신 메시지 조회
@@ -74,15 +62,10 @@ public class ChatController {
     public ResponseEntity<List<MessageResponse>> getLatestDmMessages(
             @PathVariable Integer dmRoomPk,
             @CookieValue("access_token") String jwtToken) {
-        try {
             List<MessageResponse> messages = chatService.getLatestDmMessage(dmRoomPk, jwtToken);
             log.info("DM방 최신 메시지 조회 성공: dmRoomPk={}, messageCount={}",
                     dmRoomPk, messages.size());
             return ResponseEntity.ok(messages);
-        } catch (Exception e) {
-            log.error("DM방 최신 메시지 조회 실패: {}", e.getMessage());
-            return ResponseEntity.badRequest().build();
-        }
     }
 
     // DM방 이전 메시지 조회 (무한스크롤)
@@ -91,14 +74,9 @@ public class ChatController {
             @PathVariable Integer dmRoomPk,
             @RequestParam LocalDateTime lastMessageTime,
             @CookieValue("access_token") String jwtToken) {
-        try {
             List<MessageResponse> messages = chatService.getOlderDmMessage(dmRoomPk, lastMessageTime, jwtToken);
             log.info("DM방 이전 메시지 조회 성공: dmRoomPk={}, messageCount={}, lastMessageTime={}",
                     dmRoomPk, messages.size(), lastMessageTime);
             return ResponseEntity.ok(messages);
-        } catch (Exception e) {
-            log.error("DM방 이전 메시지 조회 실패: {}", e.getMessage());
-            return ResponseEntity.badRequest().build();
-        }
     }
 }

--- a/spbackend/src/main/java/com/luminous/aurora/common/error/GlobalExceptionHandler.java
+++ b/spbackend/src/main/java/com/luminous/aurora/common/error/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.luminous.aurora.common.error;
 
 import com.luminous.aurora.common.error.exception.*;
-import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -16,7 +15,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ErrorResponseDto> handleBadRequestException(BadRequestException e) {
         ErrorResponseDto response = new ErrorResponseDto(
                 e.getMessage() != null ? e.getMessage() : "잘못된 요청입니다.",
-                "BAD_REQEUST",
+                "BAD_REQUEST",
                 HttpStatus.BAD_REQUEST.value()
         );
 

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
@@ -1,6 +1,7 @@
 package com.luminous.aurora.userstate.controller;
 
 import com.luminous.aurora.auth.repository.UserRepository;
+import com.luminous.aurora.common.error.exception.*;
 import com.luminous.aurora.jwt.JwtTokenProvider;
 import com.luminous.aurora.member.dto.DmRoomResponse;
 import com.luminous.aurora.project.entity.ProjectMember;
@@ -33,20 +34,15 @@ public class UserStateController {
     @GetMapping("/status")
     public ResponseEntity<UserStatusResponse> getCurrentUserStatus(
             HttpServletRequest request) {
-        try {
-            Integer userPk = extractUserPkFromRequest(request);
-            UserStatus status = userStateService.getUserStatus(userPk);
+        Integer userPk = extractUserPkFromRequest(request);
+        UserStatus status = userStateService.getUserStatus(userPk);
+        UserStatusResponse response = UserStatusResponse.builder()
+                .userPk(userPk)
+                .status(status)
+                .lastSeen(LocalDateTime.now()) // 실제로는 DB에서 조회
+                .build();
 
-            UserStatusResponse response = UserStatusResponse.builder()
-                    .userPk(userPk)
-                    .status(status)
-                    .lastSeen(LocalDateTime.now()) // 실제로는 DB에서 조회
-                    .build();
-
-            return ResponseEntity.ok(response);
-        } catch (Exception e) {
-            return ResponseEntity.status(401).build();
-        }
+        return ResponseEntity.ok(response);
     }
 
 
@@ -55,20 +51,16 @@ public class UserStateController {
     public ResponseEntity<UserStatusChangeResponse> setCurrentUserStatus(
             @RequestBody UserStatusChangeRequestForRest request,
             HttpServletRequest httpRequest) {
-        try {
-            Integer userPk = extractUserPkFromRequest(httpRequest);
-            userStateService.setUserStatus(userPk, request.getStatus());
+        Integer userPk = extractUserPkFromRequest(httpRequest);
+        userStateService.setUserStatus(userPk, request.getStatus());
 
-            UserStatusChangeResponse response = UserStatusChangeResponse.builder()
-                    .userPk(userPk)
-                    .status(request.getStatus())
-                    .timestamp(System.currentTimeMillis())
-                    .build();
+        UserStatusChangeResponse response = UserStatusChangeResponse.builder()
+                .userPk(userPk)
+                .status(request.getStatus())
+                .timestamp(System.currentTimeMillis())
+                .build();
 
-            return ResponseEntity.ok(response);
-        } catch (Exception e) {
-            return ResponseEntity.status(401).build();
-        }
+        return ResponseEntity.ok(response);
     }
 
     // ========== 프로젝트 멤버 조회 ==========
@@ -101,36 +93,39 @@ public class UserStateController {
      */
     @PostMapping("/member/notify")
     public ResponseEntity<String> notifyMemberChange(@RequestBody MemberChangeEvent event) {
-        try {
-            // 프로젝트 멤버 변경만 처리
-            if (event.getProjectPk() == null) {
-                return ResponseEntity.badRequest().body("프로젝트 정보가 필요합니다.");
-            }
-
-            String destination = "/topic/project/" + event.getProjectPk() + "/members";
-
-            // WebSocket으로 브로드캐스트
-            messagingTemplate.convertAndSend(destination, event);
-
-            log.info("프로젝트 멤버 변경 알림 전송: eventType={}, projectPk={}, userPk={}",
-                    event.getEventType(), event.getProjectPk(), event.getUserPk());
-
-            return ResponseEntity.ok("알림 전송 완료");
-        } catch (Exception e) {
-            log.error("멤버 변경 알림 전송 실패: {}", e.getMessage());
-            return ResponseEntity.status(500).body("알림 전송 실패: " + e.getMessage());
+        // 프로젝트 멤버 변경만 처리
+        if (event.getProjectPk() == null) {
+            throw new BadRequestException("프로젝트 정보가 필요합니다.");
         }
+
+        String destination = "/topic/project/" + event.getProjectPk() + "/members";
+
+        // WebSocket으로 브로드캐스트
+        messagingTemplate.convertAndSend(destination, event);
+
+        log.info("프로젝트 멤버 변경 알림 전송: eventType={}, projectPk={}, userPk={}",
+                event.getEventType(), event.getProjectPk(), event.getUserPk());
+
+        return ResponseEntity.ok("알림 전송 완료");
+
     }
 
-
+    /**
+     * JWT에서 userPk 추출
+     * - 토큰/사용자 없으면 UnauthorizedException → 401
+     */
     private Integer extractUserPkFromRequest(HttpServletRequest request) {
         // JWT 토큰 추출 및 userPk 반환
         String token = extractTokenFromCookie(request);
         String userEmail = jwtTokenProvider.getUserEmailFromToken(token);
         return userRepository.findUserPkByUserEmail(userEmail)
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UnauthorizedException("사용자를 찾을 수 없습니다."));
     }
 
+    /**
+     * 쿠키에서 access_token 추출
+     * - 토큰 없으면 UnauthorizedException → GlobalExceptionHandler가 401 반환
+     */
     private String extractTokenFromCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
@@ -140,6 +135,6 @@ public class UserStateController {
                 }
             }
         }
-        throw new RuntimeException("JWT 토큰을 찾을 수 없습니다.");
+        throw new UnauthorizedException("JWT 토큰을 찾을 수 없습니다.");
     }
 }


### PR DESCRIPTION
# 🐿️ Merge Requests
## 🪵 작업 브랜치
---
> fix/global-exception-handler

<br/>

## 🥔 작업 내용
---

- 컨트롤러 예외 처리 GlobalExceptionHandler로 통일
- GlobalExceptionHandler: BadRequestException import 수정, BAD_REQEUST 오타 수정
- UserStateController: extractTokenFromCookie/extractUserPkFromRequest → UnauthorizedException, try-catch 제거, notifyMemberChange → BadRequestException
- AuthController: logout/refresh @CookieValue(required=false), UnauthorizedException 사용, try-catch 제거
- ChatController: 5개 메서드 try-catch 제거
- 에러 응답 형식(ErrorResponseDto) 일관화

### try- catch 지운 이유
---
- **기존**: 컨트롤러에서 예외를 잡아 `ResponseEntity.status(401).build()` 등으로 직접 반환 → **응답 body가 비어있고, API마다 형식이 달라짐**
- **변경**: try-catch 제거 후 예외를 throw → **GlobalExceptionHandler가 처리** → `{ message, code, status }` 형식의 ErrorResponseDto로 응답
- **효과**: 에러 응답 형식 통일, 예외 처리 로직 일원화, 클라이언트에서 일관된 에러 구조로 처리 가능
- 한마디로 ai가 짜준 코드 무지성으로 적다가 globalExceptionHandler 제대로 안쓰고 있었단뜻
<br/>

## 📸 스크린샷 or 영상
(선택사항)
---


## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>