### PR TITLE
fix/#101-signup-login-validation

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/auth/controller/AuthController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.luminous.aurora.auth.dto.TokenResponse;
 import com.luminous.aurora.auth.service.AuthService;
 import com.luminous.aurora.auth.service.TokenService;
 import com.luminous.aurora.jwt.JwtTokenProvider;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,7 +36,7 @@ public class AuthController {
     private String cookieSameSite;
 
     @PostMapping("/signup")
-    public ResponseEntity<String> signup(@RequestBody SignUpRequest request) {
+    public ResponseEntity<String> signup(@Valid @RequestBody SignUpRequest request) {
         log.info("회원가입 요청 : userEmail = {}", request.getUserEmail());
         authService.signUp(request);
 
@@ -44,7 +45,7 @@ public class AuthController {
 
 
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request) {
+    public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
         log.info("로그인 요청: Email = {}",request.getUserEmail());
 
         TokenResponse tokens = authService.login(request);

--- a/spbackend/src/main/java/com/luminous/aurora/auth/dto/LoginRequest.java
+++ b/spbackend/src/main/java/com/luminous/aurora/auth/dto/LoginRequest.java
@@ -1,13 +1,17 @@
 package com.luminous.aurora.auth.dto;
 
-
+import jakarta.validation.constraints.*;
 import lombok.*;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class LoginRequest {
-    private String userEmail;
-    private String password;
 
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String userEmail;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
 }

--- a/spbackend/src/main/java/com/luminous/aurora/auth/dto/SignUpRequest.java
+++ b/spbackend/src/main/java/com/luminous/aurora/auth/dto/SignUpRequest.java
@@ -1,6 +1,7 @@
 package com.luminous.aurora.auth.dto;
 
 
+import jakarta.validation.constraints.*;
 import lombok.*;
 
 @Data
@@ -8,8 +9,16 @@ import lombok.*;
 @AllArgsConstructor
 public class SignUpRequest {
 
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String userEmail;
+
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(min = 1, max = 50, message = "이름은 1~50자 입니다.")
     private String userName;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 8, max = 100, message = "비밀번호는 8자 이상입니다.")
     private String password;
 
 }

--- a/spbackend/src/main/java/com/luminous/aurora/common/error/GlobalExceptionHandler.java
+++ b/spbackend/src/main/java/com/luminous/aurora/common/error/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.luminous.aurora.common.error.exception.*;
 import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -101,4 +102,23 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    /**
+     * Bean Validation 실패 시 (회원가입/로그인 등 @Valid 실패)
+     * - 첫 번째 필드 에러 메시지 반환
+     * - 400 Bad Request
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponseDto> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> fieldError.getDefaultMessage())
+                .findFirst()
+                .orElse("입력값이 올바르지 않습니다.");
+
+        ErrorResponseDto response = new ErrorResponseDto(
+                message,
+                "BAD_REQUEST",
+                HttpStatus.BAD_REQUEST.value()
+        );
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/spbackend/src/main/java/com/luminous/aurora/common/error/GlobalExceptionHandler.java
+++ b/spbackend/src/main/java/com/luminous/aurora/common/error/GlobalExceptionHandler.java
@@ -2,11 +2,14 @@ package com.luminous.aurora.common.error;
 
 import com.luminous.aurora.common.error.exception.*;
 import org.apache.coyote.BadRequestException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice
@@ -107,8 +110,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * - 첫 번째 필드 에러 메시지 반환
      * - 400 Bad Request
      */
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponseDto> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request
+    ) {
         String message = e.getBindingResult().getFieldErrors().stream()
                 .map(fieldError -> fieldError.getDefaultMessage())
                 .findFirst()


### PR DESCRIPTION
# 🐿️ Merge Requests
## 🪵 작업 브랜치
---
> fix/#101-signup-login-validation

<br/>

## 🥔 작업 내용
---

- 회원가입/로그인 입력값 검증 추가 (Bean Validation)
- SignUpRequest: @NotBlank, @Email, @Size (userEmail, userName, password)
- LoginRequest: @NotBlank, @Email (userEmail, password)
- AuthController: signup, login에 @Valid 적용
- GlobalExceptionHandler: handleMethodArgumentNotValid 오버라이드 추가
  - ResponseEntityExceptionHandler 상속으로 인한 Ambiguous @ExceptionHandler 해결
  - @ExceptionHandler 대신 부모 메서드 오버라이드로 변경
  - 검증 실패 시 400 Bad Request + ErrorResponseDto 반환

<br/>

## 📸 스크린샷 or 영상
(선택사항)
---


## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>