### PR TITLE
fix(#103): 초대 링크 로직 수정

### DIFF
--- a/exbackend/src/database/database.config.ts
+++ b/exbackend/src/database/database.config.ts
@@ -11,6 +11,7 @@ import { ProjectMember } from '../domain/project/entities/project-member.entity'
 import { Event } from '../domain/project/entities/event.entity';
 import { Channel } from '../domain/text-channel/entities/channel.entity';
 import { ChannelMember } from '../domain/text-channel/entities/channel-member.entity';
+import { InviteLink } from '../domain/server/entities/invite-link.entity'; // InviteLink import 추가
 
 export const getDatabaseConfig = (ConfigService: ConfigService): TypeOrmModuleOptions => ({
     type: 'postgres',
@@ -29,7 +30,8 @@ export const getDatabaseConfig = (ConfigService: ConfigService): TypeOrmModuleOp
         ProjectMember,
         Event,
         Channel,
-        ChannelMember
+        ChannelMember,
+        InviteLink
     ],
     synchronize: false,
     logging: ConfigService.get('NODE_ENV', 'development') === 'development',

--- a/exbackend/src/domain/server/controllers/server.controller.ts
+++ b/exbackend/src/domain/server/controllers/server.controller.ts
@@ -53,28 +53,27 @@ export class ServerController {
 
   @Post(':serverUrl/invite')
   @ApiOperation({ summary: '서버 초대 링크 생성' })
-  @ApiResponse({ status: 201, description: '초대 링크 생성 성공' })
-  @UseGuards(JwtAuthGuard) // ✅ 메서드 위에 데코레이터
-  @ApiBearerAuth('access-token') // Swagger용
+  @ApiResponse({ status: 201, description: '초대 링크 생성 성공', type: Object, schema: { example: { inviteHash: 'a1b2c3d4e5f6' } } }) // Swagger 응답 업데이트
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
   async generateServerInviteLink(
     @Param('serverUrl') serverUrl: string,
-    @CurrentUser() user: User // ✅ 매개변수로 추가
-  ): Promise<{ inviteLink: string }> {
-    const requestUserPk = user.userPk; // ✅ 하드코딩 대신 JWT에서 추출
+    @CurrentUser() user: User
+  ): Promise<{ inviteHash: string }> { // 반환 타입 변경
+    const requestUserPk = user.userPk;
 
     // serverUrl로 serverPk 조회
     const server = await this.serverCreationService.getServerByUrl(serverUrl);
-    const result = await this.serverInvitationService.generateInviteLink(server.serverPk, requestUserPk);
-    return { inviteLink: result.inviteLink };
+    const result = await this.serverInvitationService.generateInviteHash(server.serverPk, requestUserPk);
+    return { inviteHash: result.inviteHash };
   }
 
-  @Get(':serverUrl/join/:inviteHash')
+  @Get('/join/:inviteHash')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '초대링크 서버 정보 조회' })
   @ApiResponse({ status: 200, description: '서버 정보 조회 성공' })
   async getServerInfoByInvite(
-    @Param('serverUrl') serverUrl: string,
     @Param('inviteHash') inviteHash: string,
     @CurrentUser() user: User
   ): Promise<{

--- a/exbackend/src/domain/server/controllers/server.controller.ts
+++ b/exbackend/src/domain/server/controllers/server.controller.ts
@@ -276,20 +276,37 @@ export class ServerController {
       };
     }
   
-    @Patch(':serverUrl/leave')
-    @UseGuards(JwtAuthGuard)
-    @ApiBearerAuth('access-token')
-    @ApiOperation({ summary: '현재 유저가 서버 나가기' })
-    @ApiResponse({ status: 200, description: '서버 나가기 성공' })
-    @ApiResponse({ status: 403, description: '서버 소유자는 서버를 나갈 수 없음' })
-    @ApiResponse({ status: 404, description: '서버 또는 활성 멤버를 찾을 수 없음' })
-    async leaveServer(
-      @Param('serverUrl') serverUrl: string,
-      @CurrentUser() user: User
-    ): Promise<{ message: string }> {
-      return await this.serverInvitationService.leaveServer(
-        serverUrl,
-        user.userPk,
-      );
-    }
+  @Patch(':serverUrl/leave')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '현재 유저가 서버 나가기' })
+  @ApiResponse({ status: 200, description: '서버 나가기 성공' })
+  @ApiResponse({ status: 403, description: '서버 소유자는 서버를 나갈 수 없음' })
+  @ApiResponse({ status: 404, description: '서버 또는 활성 멤버를 찾을 수 없음' })
+  async leaveServer(
+    @Param('serverUrl') serverUrl: string,
+    @CurrentUser() user: User
+  ): Promise<{ message: string }> {
+    return await this.serverInvitationService.leaveServer(
+      serverUrl,
+      user.userPk,
+    );
   }
+
+  @Patch(':serverUrl/delete')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '서버 삭제 (Owner만 가능)' })
+  @ApiResponse({ status: 200, description: '서버 삭제 성공' })
+  @ApiResponse({ status: 401, description: '서버를 삭제할 권한 없음' })
+  @ApiResponse({ status: 404, description: '서버를 찾을 수 없음' })
+  async deleteServer(
+    @Param('serverUrl') serverUrl: string,
+    @CurrentUser() user: User,
+  ): Promise<{ message: string }> {
+    const server = await this.serverCreationService.getServerByUrl(serverUrl);
+    await this.serverDeletionService.deleteServer(server.serverPk, user.userPk);
+    return { message: '서버가 성공적으로 삭제되었습니다.' };
+  }
+}
+    

--- a/exbackend/src/domain/server/dto/server-invitation.dto.ts
+++ b/exbackend/src/domain/server/dto/server-invitation.dto.ts
@@ -4,7 +4,5 @@ export interface JoinServerDto {
 }
 
 export interface ServerInviteDto {
-  serverPk: number;
   inviteHash: string;
-  inviteLink: string;
 }

--- a/exbackend/src/domain/server/entities/invite-link.entity.ts
+++ b/exbackend/src/domain/server/entities/invite-link.entity.ts
@@ -1,0 +1,25 @@
+import { Entity, PrimaryGeneratedColumn, Column, Index, CreateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Server } from './server.entity';
+
+@Entity('invite_link')
+export class InviteLink {
+  @PrimaryGeneratedColumn({ name: 'link_pk' })
+  linkPk: number;
+
+  @Column({ type: 'varchar', length: 12, unique: true })
+  @Index({ unique: true })
+  hash: string;
+
+  @Column({ name: 'server_pk' })
+  serverPk: number;
+
+  @ManyToOne(() => Server, (server) => server.inviteLinks, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'server_pk' })
+  server: Server;
+
+  @Column({ name: 'expired_time', type: 'timestamp', nullable: false }) // NOT NULL 추가
+  expiredTime: Date;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamp' })
+  createdAt: Date;
+}

--- a/exbackend/src/domain/server/entities/server.entity.ts
+++ b/exbackend/src/domain/server/entities/server.entity.ts
@@ -3,6 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { ServerMember } from './server-member.entity';
 import { Project } from '../../project/entities/project.entity';
 import { ServerRolePermission } from './server-role-permission.entity';
+import { InviteLink } from './invite-link.entity';
 
 @Entity('server')
 export class Server {
@@ -31,4 +32,7 @@ export class Server {
 
   @OneToMany(() => ServerRolePermission, (permission) => permission.server)
   rolePermissions: ServerRolePermission[];
+
+  @OneToMany(() => InviteLink, (inviteLink) => inviteLink.server) // inviteLinks 관계 추가
+  inviteLinks: InviteLink[];
 }

--- a/exbackend/src/domain/server/server.module.ts
+++ b/exbackend/src/domain/server/server.module.ts
@@ -17,6 +17,7 @@ import { ServerController } from './controllers/server.controller';
 import { ServerRolePermissionController } from './controllers/server-role-permission.controller';
 import { ProjectModule } from '../project/project.module';
 import { ServerMemberManagementService } from './services/server-member-management.service';
+import { InviteLink } from './entities/invite-link.entity'; // InviteLink import 추가
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { ServerMemberManagementService } from './services/server-member-manageme
       ProjectMember,
       Channel,
       ChannelMember,
+      InviteLink,
     ]),
     UserModule,
     ProjectModule,

--- a/exbackend/src/domain/server/services/server-invitation.service.ts
+++ b/exbackend/src/domain/server/services/server-invitation.service.ts
@@ -2,7 +2,7 @@ import { Injectable, NotFoundException, ConflictException, ForbiddenException } 
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, In } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
-import * as crypto from 'crypto';
+import { v4 as uuidv4 } from 'uuid'; // Unique hash generation
 import { Server } from '../entities/server.entity';
 import { ServerMember } from '../entities/server-member.entity';
 import { User } from '../../user/entities/user.entity';
@@ -15,10 +15,10 @@ import { Channel } from '../../text-channel/entities/channel.entity';
 import { ChannelMember } from '../../text-channel/entities/channel-member.entity';
 import { ServerRolePermissionService } from './server-role-permission.service';
 import { PendingMemberDto, ServerMemberInfoDto, ServerMemberDetailDto, UpdateMemberStatusDto, JoinServerDto, ServerInviteDto } from '../dto';
+import { InviteLink } from '../entities/invite-link.entity'; // InviteLink entity 추가
 
 @Injectable()
 export class ServerInvitationService {
-  private readonly INVITE_SALT = 'server_invite_salt_2024'; // 환경변수로 관리 권장
 
   constructor(
     @InjectRepository(Server)
@@ -36,36 +36,14 @@ export class ServerInvitationService {
     private readonly channelRepository: Repository<Channel>,
     @InjectRepository(ChannelMember)
     private readonly channelMemberRepository: Repository<ChannelMember>,
+    @InjectRepository(InviteLink) // InviteLink Repository 주입
+    private readonly inviteLinkRepository: Repository<InviteLink>,
     private readonly configService: ConfigService,
     private readonly serverRolePermissionService: ServerRolePermissionService,
   ) {}
 
-  // serverPk를 해시로 변환
-  private generateInviteHash(serverPk: number): string {
-    return crypto
-      .createHash('sha256')
-      .update(`${serverPk}-${this.INVITE_SALT}`)
-      .digest('hex')
-      .substring(0, 16); // 16자리 해시
-  }
-
-  // 해시를 serverPk로 역변환 (모든 서버를 순회해서 매칭)
-  private async getServerPkFromHash(inviteHash: string): Promise<number | null> {
-    const servers = await this.serverRepository.find({
-      where: { isDeletedServer: false },
-      select: ['serverPk']
-    });
-
-    for (const server of servers) {
-      if (this.generateInviteHash(server.serverPk) === inviteHash) {
-        return server.serverPk;
-      }
-    }
-    return null;
-  }
-
   // 서버 초대 링크 생성
-  async generateInviteLink(serverPk: number, requestUserPk: number): Promise<ServerInviteDto> {
+  async generateInviteHash(serverPk: number, requestUserPk: number): Promise<{ inviteHash: string }> {
     // 1. 서버 존재 확인
     const server = await this.serverRepository.findOne({
       where: { serverPk, isDeletedServer: false }
@@ -88,15 +66,23 @@ export class ServerInvitationService {
       throw new ForbiddenException('서버 관리자 또는 소유자만 초대 링크를 생성할 수 있습니다');
     }
 
-    // 3. 해시 생성 및 링크 생성
-    const inviteHash = this.generateInviteHash(serverPk);
-    const baseUrl = this.configService.get('SERVER_URL', 'http://localhost:3001'); // env에 배포용 서버 URL 있으면 그거 사용, 없으면 localhost 사용
-    const inviteLink = `${baseUrl}/api/ex/servers/${server.serverUrl}/join/${inviteHash}`;
+    // 3. 고유 해시 생성 (UUID 사용)
+    const newInviteHash = uuidv4().substring(0, 12); // 12자리 해시
+
+    // 4. 만료 시간 설정 (현재 시간 + 7일)
+    const expiredTime = new Date();
+    expiredTime.setDate(expiredTime.getDate() + 7);
+
+    // 5. 초대 링크 정보 저장
+    const inviteLinkEntity = this.inviteLinkRepository.create({
+      serverPk: server.serverPk,
+      hash: newInviteHash,
+      expiredTime: expiredTime,
+    });
+    await this.inviteLinkRepository.save(inviteLinkEntity);
 
     return {
-      serverPk,
-      inviteHash,
-      inviteLink,
+      inviteHash: newInviteHash,
     };
   }
 
@@ -195,23 +181,30 @@ export class ServerInvitationService {
 
   // 초대 링크로 서버 정보 조회
   async getServerInfoByInvite(joinDto: JoinServerDto): Promise<{ serverUrl: string; serverName: string }> {
-    // 1. 해시로 서버 찾기
-    const serverPk = await this.getServerPkFromHash(joinDto.inviteHash);
+    // 1. 해시로 초대 링크 찾기
+    const inviteLinkRecord = await this.inviteLinkRepository.findOne({
+      where: { hash: joinDto.inviteHash },
+    });
 
-    if (!serverPk) {
+    if (!inviteLinkRecord) {
       throw new NotFoundException('잘못된 초대 링크입니다');
     }
 
-    // 2. 서버 존재 확인
+    // 2. 만료 시간 검증
+    if (inviteLinkRecord.expiredTime < new Date()) {
+      throw new ForbiddenException('만료된 초대 링크입니다');
+    }
+
+    // 3. 서버 존재 확인
     const server = await this.serverRepository.findOne({
-      where: { serverPk, isDeletedServer: false }
+      where: { serverPk: inviteLinkRecord.serverPk, isDeletedServer: false }
     });
 
     if (!server) {
-      throw new NotFoundException('서버를 찾을 수 없거나 삭제되었습니다');
+      throw new NotFoundException('서버를 찾을 수 없습니다');
     }
 
-    // 3. 사용자 존재 확인 (유효한 사용자인지만 확인)
+    // 4. 사용자 존재 확인 (유효한 사용자인지만 확인)
     const user = await this.userRepository.findOne({
       where: { userPk: joinDto.userPk, isDeleted: false }
     });
@@ -220,7 +213,7 @@ export class ServerInvitationService {
       throw new NotFoundException(`사용자 ID ${joinDto.userPk}를 찾을 수 없습니다`);
     }
 
-    // 4. 서버 정보만 반환
+    // 5. 서버 정보 반환
     return {
       serverUrl: server.serverUrl,
       serverName: server.serverName


### PR DESCRIPTION
# 🐿️ Merge Requests
## 🪵 작업 브랜치
---
> fix/#103-invite-by-link

<br/>

## 🥔 작업 내용
---

- 초대 링크 생성 요청 시 해시 값 응답 반환
- 해쉬 붙은 초대 링크로 접근 시 서버 이름, 서버 url 반환
- 링크 해시값 만료 기간 7일로 설정

<br/>

## 📸 스크린샷 or 영상
(선택사항)
---


## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>