### PR TITLE
feature(#116) : Express 내부 API 보안 분리

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/config/InternalApiAuthFilter.java
+++ b/spbackend/src/main/java/com/luminous/aurora/config/InternalApiAuthFilter.java
@@ -1,0 +1,42 @@
+package com.luminous.aurora.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class InternalApiAuthFilter extends OncePerRequestFilter {
+
+    @Value("${internal.secret}")
+    private String internalSecret;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String header = request.getHeader("X-Internal-Secret");
+
+        if (!internalSecret.equals(header)) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"message\" : \"Forbidden\"}");
+            return;
+        }
+
+        filterChain.doFilter(request,response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !request.getRequestURI().startsWith("/api/jv/internal/");
+    }
+}

--- a/spbackend/src/main/java/com/luminous/aurora/config/SecurityConfig.java
+++ b/spbackend/src/main/java/com/luminous/aurora/config/SecurityConfig.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final InternalApiAuthFilter internalApiAuthFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
@@ -35,10 +36,12 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/").permitAll() // 루트경로 허용
                         .requestMatchers("/api/jv/login","/api/jv/signup","/api/jv/refresh").permitAll() // 인증관련 api 전부 허용
+                        .requestMatchers("/api/jv/internal/**").permitAll() // 내부경로 허용
                         .requestMatchers("/ws/info").permitAll() // 웹소켓 연결을 위한 SockJS 허용
                         .requestMatchers("/ws/**").authenticated() // Websocket 연결은 인증
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(internalApiAuthFilter, JwtAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/spbackend/src/main/java/com/luminous/aurora/internal/controller/InternalController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/internal/controller/InternalController.java
@@ -1,0 +1,45 @@
+package com.luminous.aurora.internal.controller;
+
+
+import com.luminous.aurora.common.error.exception.BadRequestException;
+import com.luminous.aurora.userstate.dto.MemberChangeEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("api/jv/internal")
+@RequiredArgsConstructor
+public class InternalController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * Express에서 멤버 변경 시 호출하는 API
+     * Express에서 받은 MemberChangeEvent를 그대로 다시 프론트에게 전달
+     */
+    @PostMapping("/member/notify")
+    public ResponseEntity<String> notifyMemberChange(@RequestBody MemberChangeEvent event) {
+        // 프로젝트 멤버 변경만 처리
+        if (event.getProjectPk() == null) {
+            throw new BadRequestException("프로젝트 정보가 필요합니다.");
+        }
+
+        String destination = "/topic/project/" + event.getProjectPk() + "/members";
+
+        // WebSocket으로 가공없이 브로드캐스트
+        messagingTemplate.convertAndSend(destination, event);
+
+        log.info("프로젝트 멤버 변경 알림 전송: eventType={}, projectPk={}, userPk={}",
+                event.getEventType(), event.getProjectPk(), event.getUserPk());
+
+        return ResponseEntity.ok("알림 전송 완료");
+
+    }
+}

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
@@ -15,7 +15,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -30,7 +29,6 @@ public class UserStateController {
     private final UserStateService userStateService;
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
-    private final SimpMessagingTemplate messagingTemplate;
     private final MemberService memberService;
 
     //사용자 상태 조회
@@ -108,27 +106,6 @@ public class UserStateController {
     }
 
 
-    /**
-     * Express에서 멤버 변경 시 호출하는 API
-     */
-    @PostMapping("/member/notify")
-    public ResponseEntity<String> notifyMemberChange(@RequestBody MemberChangeEvent event) {
-        // 프로젝트 멤버 변경만 처리
-        if (event.getProjectPk() == null) {
-            throw new BadRequestException("프로젝트 정보가 필요합니다.");
-        }
-
-        String destination = "/topic/project/" + event.getProjectPk() + "/members";
-
-        // WebSocket으로 브로드캐스트
-        messagingTemplate.convertAndSend(destination, event);
-
-        log.info("프로젝트 멤버 변경 알림 전송: eventType={}, projectPk={}, userPk={}",
-                event.getEventType(), event.getProjectPk(), event.getUserPk());
-
-        return ResponseEntity.ok("알림 전송 완료");
-
-    }
 
     /**
      * JWT에서 userPk 추출

--- a/spbackend/src/main/resources/application.yml
+++ b/spbackend/src/main/resources/application.yml
@@ -52,3 +52,6 @@ logging:
 cookie:
   secure: true
   same-site: Strict
+
+internal:
+  secret: ${INTERNAL_SECRET}


### PR DESCRIPTION
# 🐿️ Merge Requests
## 🪵 작업 브랜치
---
> feature/#116-separate-internal-express-api

<br/>

## 🥔 작업 내용
---

- `/api/jv/userstate/member/notify` → `/api/jv/internal/member/notify` 경로 분리
- `InternalController` 생성으로 내부 API와 클라이언트 API 컨트롤러 분리
- `InternalApiAuthFilter` 생성으로 `X-Internal-Secret` 헤더 기반 인증 적용
- `SecurityConfig`에 내부 경로 permitAll 및 필터 등록
- `application.yml`에 `internal.secret` 환경변수 추가

<br/>

## 📸 스크린샷 or 영상
(선택사항)
---

## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>