### PR TITLE
fix(#120): SecurityConfig addFilterBefore 등록 순서 수정

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/config/SecurityConfig.java
+++ b/spbackend/src/main/java/com/luminous/aurora/config/SecurityConfig.java
@@ -41,8 +41,8 @@ public class SecurityConfig {
                         .requestMatchers("/ws/**").authenticated() // Websocket 연결은 인증
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(internalApiAuthFilter, JwtAuthenticationFilter.class)
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(internalApiAuthFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치
---
> fix(#120)-jwt-filter-order

<br/>

## 🥔 작업 내용
---

- InternalApiAuthFilter 추가 시 발생한 "JwtAuthenticationFilter does not have a registered order" 오류 해결
- SecurityConfig filterChain에서 addFilterBefore 선언 순서 변경
  - JwtAuthenticationFilter를 UsernamePasswordAuthenticationFilter 기준으로 먼저 등록
  - InternalApiAuthFilter를 JwtAuthenticationFilter 기준으로 이후 등록
- 필터 실행 순서는 유지 (InternalApiAuthFilter → JwtAuthenticationFilter → UsernamePasswordAuthenticationFilter)

<br/>

## 📸 스크린샷 or 영상
---
(선택사항)

<br/>

## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>