### PR TITLE
fix : auth validation error response message

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/common/error/GlobalExceptionHandler.java
+++ b/spbackend/src/main/java/com/luminous/aurora/common/error/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.luminous.aurora.common.error;
 
 import com.luminous.aurora.common.error.exception.*;
-import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -110,13 +109,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * - 첫 번째 필드 에러 메시지 반환
      * - 400 Bad Request
      */
-    @Override
-    public ResponseEntity<Object> handleMethodArgumentNotValid(
-            MethodArgumentNotValidException e,
-            HttpHeaders headers,
-            HttpStatusCode status,
-            WebRequest request
-    ) {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
         String message = e.getBindingResult().getFieldErrors().stream()
                 .map(fieldError -> fieldError.getDefaultMessage())
                 .findFirst()


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> fix/-auth-dto-validation-error-response-message

<br/>

## 🥔 작업 내용

---

- `GlobalExceptionHandler`에 `MethodArgumentNotValidException` 전용 `@ExceptionHandler` 추가
- DTO 검증 실패 시 클라이언트에 "이메일은 필수입니다.", "비밀번호는 필수입니다." 등 실제 검증 메시지가 400 Bad Request로 반환되도록 수정
- `BadRequestException` import를 프로젝트 패키지(`com.luminous.aurora.common.error.exception`)로 변경

<br/>

## 📸 스크린샷 or 영상

(선택사항)

<br/>

## 💥 확인해주세요!

---

- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>