### PR TITLE
feature : 프로젝트 채널 변경 알림 기능 개발

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/internal/controller/InternalController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/internal/controller/InternalController.java
@@ -2,10 +2,7 @@ package com.luminous.aurora.internal.controller;
 
 
 import com.luminous.aurora.common.error.exception.BadRequestException;
-import com.luminous.aurora.internal.dto.ChannelChangeBroadCast;
-import com.luminous.aurora.internal.dto.ChannelChangeEvent;
-import com.luminous.aurora.internal.dto.ChannelMemberBroadcast;
-import com.luminous.aurora.internal.dto.MemberChangeEvent;
+import com.luminous.aurora.internal.dto.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -80,6 +77,36 @@ public class InternalController {
 
         log.info("채널 정보 변경 알림 전송 : eventType = {}, channelPk = {}, channelName = {}",
                 event.getEventType(), event.getChannelPk(), event.getChannelName());
+
+        return ResponseEntity.ok("알림 전송 완료");
+    }
+
+    /**
+     * Express에서 프로젝트 정보 변경 시 호출하는 API
+     * Express에서 프로젝트 정보 변경 시 호출, ServerUrl 제외하고 프론트에 브로드캐스트
+     */
+    @PostMapping("/project/notify")
+    public ResponseEntity<String> notifyProjectChange(@RequestBody ProjectChangeEvent event) {
+
+        if (event.getProjectPk() == null) {
+            throw new BadRequestException("프로젝트 정보가 필요합니다.");
+        }
+
+        if (event.getServerUrl() == null) {
+            throw new BadRequestException("서버 정보가 필요합니다.");
+        }
+
+        ProjectChangeBroadCast broadCast = ProjectChangeBroadCast.builder()
+                .eventType(event.getEventType())
+                .projectPk(event.getProjectPk())
+                .projectName(event.getProjectName())
+                .build();
+
+        String destination = "/topic/server/" + event.getServerUrl() + "/notify";
+        messagingTemplate.convertAndSend(destination, broadCast);
+
+        log.info("프로젝트 정보 변경 알림 전송 : eventType = {}, projectPk = {}, projectName = {}",
+                event.getEventType(), event.getProjectPk(), event.getProjectName());
 
         return ResponseEntity.ok("알림 전송 완료");
     }

--- a/spbackend/src/main/java/com/luminous/aurora/internal/dto/ProjectChangeBroadCast.java
+++ b/spbackend/src/main/java/com/luminous/aurora/internal/dto/ProjectChangeBroadCast.java
@@ -1,0 +1,14 @@
+package com.luminous.aurora.internal.dto;
+
+import lombok.*;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+// Spring -> frontend 발신 dto
+public class ProjectChangeBroadCast {
+    private String eventType; // "PROJECT_ADDED" | "PROJECT_REMOVED" | "PROJECT_UPDATED"
+    private Integer projectPk;
+    private String projectName;
+}

--- a/spbackend/src/main/java/com/luminous/aurora/internal/dto/ProjectChangeEvent.java
+++ b/spbackend/src/main/java/com/luminous/aurora/internal/dto/ProjectChangeEvent.java
@@ -1,0 +1,16 @@
+package com.luminous.aurora.internal.dto;
+
+import lombok.*;
+
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+// Express -> Spring 수신 dto
+public class ProjectChangeEvent {
+    private String eventType; // "PROJECT_ADDED" | "PROJECT_REMOVED" | "PROJECT_UPDATE"
+    private Integer projectPk;
+    private String projectName;
+    private String serverUrl;
+}


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> feature/148-project-change-notify

<br/>

## 🥔 작업 내용

---

- Express에서 프로젝트 추가/삭제/이름 변경 시 호출하는 Internal API(`POST /api/jv/internal/project/notify`) 구현
- ProjectChangeEvent(Express→Spring 수신 DTO), ProjectChangeBroadCast(Spring→Frontend 발신 DTO) 추가
- 서버 단위 WebSocket 브로드캐스트(`/topic/server/{serverUrl}/notify`) 구현

<br/>

## 📸 스크린샷 or 영상

<img width="821" height="120" alt="image" src="https://github.com/user-attachments/assets/f7049f5c-3b9d-469e-9f91-f1f572edea45" />

<img width="425" height="504" alt="image" src="https://github.com/user-attachments/assets/e57d5be7-0ec0-4042-8ea2-a38ce0178715" />

## 💥 확인해주세요!

---

- [x] 모든 기능이 제대로 동작하는지 확인해주세요.
- [x] 컨벤션을 제대로 지켰는지 확인해주세요.
- [x] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>