### PR TITLE
fix(#157): 유저 이메일을 pk로 변환하지 못하던 문제 수정

### DIFF
--- a/exbackend/src/domain/user/interceptors/user-population.interceptor.ts
+++ b/exbackend/src/domain/user/interceptors/user-population.interceptor.ts
@@ -1,0 +1,28 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { UserService } from '../services/user.service';
+
+@Injectable()
+export class UserPopulationInterceptor implements NestInterceptor {
+  constructor(private readonly userService: UserService) {}
+
+  async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
+    const request = context.switchToHttp().getRequest();
+    const userEmail = request.user; // JwtStrategy가 반환한 이메일 문자열
+
+    // 만약 request.user가 이미 객체이거나 이메일이 없다면 통과
+    if (typeof userEmail === 'string') {
+      
+      try {
+        const user = await this.userService.getUserByEmail(userEmail);
+        if (user) {
+          request.user = user;
+        }
+      } catch (error) {
+        console.error(`[UserPopulationInterceptor] Failed to fetch user: ${error.message}`);
+      }
+    }
+
+    return next.handle();
+  }
+}

--- a/exbackend/src/domain/user/user.module.ts
+++ b/exbackend/src/domain/user/user.module.ts
@@ -7,6 +7,10 @@ import { UserServiceImpl } from './services/serviceImpl/user.service.impl';
 import { UserRepository } from './repositories/user.repository';
 import { TypeOrmUserRepository } from './repositories/repositoryImpl/typeorm-user.repository'
 
+// interceptor
+ import { UserPopulationInterceptor } from './interceptors/user-population.interceptor';
+ import { APP_INTERCEPTOR } from '@nestjs/core';
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([User, UserOption]),
@@ -21,6 +25,10 @@ import { TypeOrmUserRepository } from './repositories/repositoryImpl/typeorm-use
       provide: UserRepository,
       useClass: TypeOrmUserRepository,
     },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: UserPopulationInterceptor,
+    }
   ],
   exports: [UserService], 
 })


### PR DESCRIPTION
# 🐿️ Merge Requests
## 🪵 작업 브랜치
---
> fix/#157-user-info

<br/>

## 🥔 작업 내용
---

- userEmail를 PK로 변환하지 못하던 문제 수정
    - 토큰에서 userEamil를 그대로 반환해서 파라미터에 집어넣고 있었음
    - interceptor를 통해 중간에서 이메일을 pk로 변환하는 과정 추가함
    - 원인은 auth를 user로 부터 분리하면서 생겼음

<br/>

## 📸 스크린샷 or 영상
(선택사항)
---


## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>