### PR TITLE
refactor(#159) : 멤버 조회 API를 프로젝트 단위에서 채널 단위로 변경

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/member/dto/ChannelMemberResponse.java
+++ b/spbackend/src/main/java/com/luminous/aurora/member/dto/ChannelMemberResponse.java
@@ -1,0 +1,15 @@
+package com.luminous.aurora.member.dto;
+
+
+import com.luminous.aurora.userstate.entity.UserStatus;
+import lombok.*;
+
+@Builder
+@Getter
+public class ChannelMemberResponse {
+    private String userName;
+    private String userEmail;
+    private String profileImage;
+    private String channelRole;
+    private UserStatus userStatus;
+}

--- a/spbackend/src/main/java/com/luminous/aurora/member/repository/ChannelMemberRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/member/repository/ChannelMemberRepository.java
@@ -4,6 +4,7 @@ import com.luminous.aurora.member.entity.ChannelMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +16,8 @@ public interface ChannelMemberRepository extends JpaRepository<ChannelMember, In
 
     // 채널 멤버 존재 여부 확인
     boolean existsByChannel_ChannelPkAndUser_UserPk(Integer channelPk, Integer userPk);
+
+    // 채널별 멤버 조회
+    List<ChannelMember> findByChannel_ChannelPk(Integer channelPk);
+
 }

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
@@ -4,9 +4,9 @@ import com.luminous.aurora.auth.repository.UserRepository;
 import com.luminous.aurora.common.error.exception.*;
 import com.luminous.aurora.common.error.exception.ForbiddenException;
 import com.luminous.aurora.jwt.JwtTokenProvider;
+import com.luminous.aurora.member.dto.ChannelMemberResponse;
 import com.luminous.aurora.member.dto.DmRoomResponse;
 import com.luminous.aurora.member.service.MemberService;
-import com.luminous.aurora.project.entity.ProjectMember;
 import com.luminous.aurora.userstate.dto.*;
 import com.luminous.aurora.userstate.entity.UserStatus;
 import com.luminous.aurora.userstate.service.UserStateService;
@@ -64,26 +64,26 @@ public class UserStateController {
         return ResponseEntity.ok(response);
     }
 
-    // ========== 프로젝트 멤버 조회 ==========
+    // ========== 채널 멤버 조회 ==========
 
     /**
-     * 프로젝트 멤버 조회 (권한별 + 상태별 + 가나다순)
-     * - IDOR 방지 : 프로젝트 멤버인지 검증 후 조회
+     * 채널 멤버 조회 (권한별 + 상태별 + 가나다순)
+     * - IDOR 방지 : 채널 멤버인지 검증 후 조회
      * - 미멤버 요청 시 403 Forbidden
      */
-    @GetMapping("/project/{projectPk}/members")
-    public ResponseEntity<List<ProjectMember>> getProjectMembers(
-            @PathVariable Integer projectPk,
+    @GetMapping("/channel/{channelPk}/members")
+    public ResponseEntity<List<ChannelMemberResponse>> getChannelMembers(
+            @PathVariable Integer channelPk,
             HttpServletRequest request) {
         try {
             // JWT에서 현재 사용자 PK 추출
             Integer userPk = extractUserPkFromRequest(request);
 
-            // 프로젝트 멤버가 아니면 403
-            if (!memberService.hasProjectAccess(projectPk, userPk)) {
-                throw new ForbiddenException("해당 프로젝트에 접근할 권한이 없습니다.");
+            // 채널 멤버가 아니면 403
+            if (!memberService.hasChannelAccess(channelPk, userPk)) {
+                throw new ForbiddenException("해당 채널에 접근할 권한이 없습니다.");
             }
-            List<ProjectMember> members = userStateService.getProjectMembersWithStatus(projectPk);
+            List<ChannelMemberResponse> members = userStateService.getChannelMemberWithStatus(channelPk);
 
             return ResponseEntity.ok(members);
         } catch (ForbiddenException e) {

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateService.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateService.java
@@ -1,7 +1,7 @@
 package com.luminous.aurora.userstate.service;
 
+import com.luminous.aurora.member.dto.ChannelMemberResponse;
 import com.luminous.aurora.member.dto.DmRoomResponse;
-import com.luminous.aurora.project.entity.ProjectMember;
 import com.luminous.aurora.userstate.entity.UserStatus;
 
 import java.util.List;
@@ -24,13 +24,13 @@ public interface UserStateService {
     // 사용자 오프라인 상태 설정(자동)
     void setUserOffline(Integer userPk);
 
-    // ==== 프로젝트 멤버 조회===
+    // ==== 채널 멤버 조회===
 
-    // 프로젝트 멤버 조회 (권한별 + 상태별 + 가나다순)
+    // 채널 멤버 조회 (권한별 + 상태별 + 가나다순)
     // 온라인/자리비움/방해금지 : 권한별로 나누고 가나다순
     // 오프라인 : 권한 구분 없이 가나다순
 
-    List<ProjectMember> getProjectMembersWithStatus(Integer projectPk);
+    List<ChannelMemberResponse> getChannelMemberWithStatus(Integer channelPk);
 
     // ===== DM 멤버 조회 ========
     // DM멤버 조회 (최신 메시지순 + 상태 + unreadCount)

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateServiceImpl.java
@@ -6,11 +6,12 @@ import com.luminous.aurora.common.error.exception.BadRequestException;
 import com.luminous.aurora.common.error.exception.ForbiddenException;
 import com.luminous.aurora.common.error.exception.InternalServerErrorException;
 import com.luminous.aurora.common.error.exception.NotFoundException;
+import com.luminous.aurora.member.dto.ChannelMemberResponse;
 import com.luminous.aurora.member.dto.DmRoomResponse;
+import com.luminous.aurora.member.entity.ChannelMember;
 import com.luminous.aurora.member.entity.DmMember;
+import com.luminous.aurora.member.repository.ChannelMemberRepository;
 import com.luminous.aurora.member.repository.DmMemberRepository;
-import com.luminous.aurora.project.entity.ProjectMember;
-import com.luminous.aurora.project.repository.ProjectMemberRepository;
 import com.luminous.aurora.userstate.entity.UserState;
 import com.luminous.aurora.userstate.entity.UserStatus;
 import com.luminous.aurora.userstate.repository.UserStateRedisRepository;
@@ -32,7 +33,7 @@ public class UserStateServiceImpl implements UserStateService {
 
     private final UserStateRepository userStateRepository;
     private final UserStateRedisRepository redisRepository;
-    private final ProjectMemberRepository projectMemberRepository;
+    private final ChannelMemberRepository channelMemberRepository;
     private final DmMemberRepository dmMemberRepository;
     private final MessageRepository messageRepository;
 
@@ -125,36 +126,39 @@ public class UserStateServiceImpl implements UserStateService {
         }
     }
 
-    // ========== 프로젝트 멤버 조회 ==========
+    // ========== 채널 멤버 조회 ==========
 
     @Override
-    public List<ProjectMember> getProjectMembersWithStatus(Integer projectPk) {
+    public List<ChannelMemberResponse> getChannelMemberWithStatus(Integer channelPk) {
         try {
-            // 1. 프로젝트 멤버 조회
-            List<ProjectMember> members = projectMemberRepository.findByProject_ProjectPk(projectPk);
+            // 1. 채널 멤버 조회
+            List<ChannelMember> members = channelMemberRepository.findByChannel_ChannelPk(channelPk);
 
             // 2. 상태별로 그룹화
-            Map<UserStatus, List<ProjectMember>> statusGroups = new HashMap<>();
+            Map<UserStatus, List<ChannelMember>> statusGroups = new HashMap<>();
+            Map<Integer, UserStatus> statusCache = new HashMap<>();
 
-            for (ProjectMember member : members) {
-                UserStatus status = getUserStatus(member.getUser().getUserPk());
+            for (ChannelMember member : members) {
+                Integer userPk = member.getUser().getUserPk();
+                UserStatus status = getUserStatus(userPk);
+                statusCache.put(userPk, status);
                 statusGroups.computeIfAbsent(status, k -> new ArrayList<>()).add(member);
             }
 
             // 3. 정렬 및 조합
-            List<ProjectMember> result = new ArrayList<>();
+            List<ChannelMember> result = new ArrayList<>();
 
             // 온라인/자리비움/방해금지: 권한별로 나누고 가나다순
             for (UserStatus status : Arrays.asList(UserStatus.ONLINE, UserStatus.AWAY, UserStatus.DND)) {
-                List<ProjectMember> statusMembers = statusGroups.getOrDefault(status, new ArrayList<>());
+                List<ChannelMember> statusMembers = statusGroups.getOrDefault(status, new ArrayList<>());
 
                 // 권한별로 그룹화
-                Map<String, List<ProjectMember>> roleGroups = statusMembers.stream()
-                        .collect(Collectors.groupingBy(ProjectMember::getProjectRole));
+                Map<String, List<ChannelMember>> roleGroups = statusMembers.stream()
+                        .collect(Collectors.groupingBy(ChannelMember::getChannelRole));
 
                 // admin 먼저, member 나중에
                 for (String role : Arrays.asList("admin", "member")) {
-                    List<ProjectMember> roleMembers = roleGroups.getOrDefault(role, new ArrayList<>());
+                    List<ChannelMember> roleMembers = roleGroups.getOrDefault(role, new ArrayList<>());
 
                     // 가나다순 정렬
                     roleMembers.sort(Comparator.comparing(m -> m.getUser().getUserName()));
@@ -163,16 +167,27 @@ public class UserStateServiceImpl implements UserStateService {
             }
 
             // 오프라인: 권한 구분 없이 가나다순
-            List<ProjectMember> offlineMembers = statusGroups.getOrDefault(UserStatus.OFFLINE, new ArrayList<>());
+            List<ChannelMember> offlineMembers = statusGroups.getOrDefault(UserStatus.OFFLINE, new ArrayList<>());
             offlineMembers.sort(Comparator.comparing(m -> m.getUser().getUserName()));
             result.addAll(offlineMembers);
 
-            return result;
+            // 4. DTO 변환
+            return result.stream()
+                    .map(member -> {
+                        return ChannelMemberResponse.builder()
+                                .userName(member.getUser().getUserName())
+                                .userEmail(member.getUser().getUserEmail())
+                                .profileImage(member.getUser().getProfileImagePath())
+                                .channelRole(member.getChannelRole())
+                                .userStatus(statusCache.get(member.getUser().getUserPk()))
+                                .build();
+                    })
+                    .collect(Collectors.toList());
         } catch (NotFoundException | BadRequestException | ForbiddenException e) {
             throw e;
         } catch (Exception e) {
-            log.error("프로젝트 멤버 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("프로젝트 멤버 조회 중 서버 오류가 발생했습니다: " + e.getMessage());
+            log.error("채널 멤버 조회 실패 : {}", e.getMessage());
+            throw new InternalServerErrorException("채널 멤버 조회 중 서버 오류가 발생했습니다: " + e.getMessage());
         }
     }
 
@@ -234,11 +249,11 @@ public class UserStateServiceImpl implements UserStateService {
                                 .unreadCount(unreadCount)
                                 .build();
                     })
-                    .filter(response -> response!= null)
+                    .filter(response -> response != null)
                     .collect(Collectors.toList());
         } catch (Exception e) {
             log.error("DM 목록 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("DM 목록 조회 중 오류 발생 : " +e.getMessage());
+            throw new InternalServerErrorException("DM 목록 조회 중 오류 발생 : " + e.getMessage());
         }
     }
 }


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> refactor/-channel-member-list-api

<br/>

## 🥔 작업 내용

---

- 멤버 조회 API를 프로젝트 단위에서 채널 단위로 변경 (`/project/{projectPk}/members` → `/channel/{channelPk}/members`)
- 응답 DTO(`ChannelMemberResponse`) 생성하여 엔티티 직접 노출 방지
- 권한 검증을 `hasProjectAccess` → `hasChannelAccess`로 변경
- 상태 조회 시 `statusCache`를 활용하여 Redis/DB 중복 호출 제거

<br/>

## 📸 스크린샷 or 영상

(선택사항)

## 💥 확인해주세요!

---

- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>