### PR TITLE
fix(#161): 채널 멤버 조회 시 Active 상태만 필터링

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/member/repository/ChannelMemberRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/member/repository/ChannelMemberRepository.java
@@ -17,7 +17,6 @@ public interface ChannelMemberRepository extends JpaRepository<ChannelMember, In
     // 채널 멤버 존재 여부 확인
     boolean existsByChannel_ChannelPkAndUser_UserPk(Integer channelPk, Integer userPk);
 
-    // 채널별 멤버 조회
-    List<ChannelMember> findByChannel_ChannelPk(Integer channelPk);
-
+    // Active 상태인 채널 멤버만 조회
+    List<ChannelMember> findByChannel_ChannelPkAndCStatus(Integer channelPk, String cStatus);
 }

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateServiceImpl.java
@@ -131,8 +131,8 @@ public class UserStateServiceImpl implements UserStateService {
     @Override
     public List<ChannelMemberResponse> getChannelMemberWithStatus(Integer channelPk) {
         try {
-            // 1. 채널 멤버 조회
-            List<ChannelMember> members = channelMemberRepository.findByChannel_ChannelPk(channelPk);
+            // 1. 채널 Active 멤버 조회
+            List<ChannelMember> members = channelMemberRepository.findByChannel_ChannelPkAndCStatus(channelPk,"Active");
 
             // 2. 상태별로 그룹화
             Map<UserStatus, List<ChannelMember>> statusGroups = new HashMap<>();


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> fix/-channel-member-active-filter

<br/>

## 🥔 작업 내용

---

- 채널 멤버 조회 시 cStatus가 Active인 멤버만 반환하도록 필터링 추가
- Repository에 `findByChannel_ChannelPkAndCStatus` 메서드 추가하여 DB 레벨에서 필터링
- 기존 `findByChannel_ChannelPk` 메서드 제거 (미사용)

<br/>

## 📸 스크린샷 or 영상

(선택사항)

## 💥 확인해주세요!

---

- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>