### PR TITLE
fix(#161) : cStatus 필드 매핑 오류 수정 (@Query 적용)

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/member/repository/ChannelMemberRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/member/repository/ChannelMemberRepository.java
@@ -2,6 +2,8 @@ package com.luminous.aurora.member.repository;
 
 import com.luminous.aurora.member.entity.ChannelMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -18,5 +20,7 @@ public interface ChannelMemberRepository extends JpaRepository<ChannelMember, In
     boolean existsByChannel_ChannelPkAndUser_UserPk(Integer channelPk, Integer userPk);
 
     // Active 상태인 채널 멤버만 조회
-    List<ChannelMember> findByChannel_ChannelPkAndCStatus(Integer channelPk, String cStatus);
+    // cStatus가 c 단일 문자로 시작해 CStatus로 매핑이 제대로 되지 않아 @Query 어노테이션으로 직접 JPQL 작성
+    @Query("SELECT cm FROM ChannelMember cm WHERE cm.channel.channelPk = :channelPk AND cm.cStatus = :cStatus")
+    List<ChannelMember> findByChannelPkAndCStatus(@Param("channelPk") Integer channelPk, @Param("cStatus") String cStatus);
 }

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateServiceImpl.java
@@ -132,7 +132,7 @@ public class UserStateServiceImpl implements UserStateService {
     public List<ChannelMemberResponse> getChannelMemberWithStatus(Integer channelPk) {
         try {
             // 1. 채널 Active 멤버 조회
-            List<ChannelMember> members = channelMemberRepository.findByChannel_ChannelPkAndCStatus(channelPk,"Active");
+            List<ChannelMember> members = channelMemberRepository.findByChannelPkAndCStatus(channelPk,"Active");
 
             // 2. 상태별로 그룹화
             Map<UserStatus, List<ChannelMember>> statusGroups = new HashMap<>();


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> fix/-channel-member-active-filter

<br/>

## 🥔 작업 내용

---

- cStatus 필드의 단일 문자 접두사로 인한 Spring Data JPA 메서드 네이밍 매핑 오류 수정
- `findByChannel_ChannelPkAndCStatus` → `@Query` 어노테이션 JPQL로 변경
- ServiceImpl 호출부 메서드명 동기화

<br/>

## 📸 스크린샷 or 영상

(선택사항)

## 💥 확인해주세요!

---

- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>