### PR TITLE
refactor(#164) : WebSocket과 중복되는 REST 메시지 저장 API 제거

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
@@ -20,20 +20,6 @@ public class ChatController {
 
     private final ChatService chatService;
 
-    // 채널 메시지 저장
-    @PostMapping("/channel")
-    public ResponseEntity<String> saveChannelMessage(
-            @RequestBody MessageRequest request,
-            @CookieValue("access_token") String jwtToken) {
-        // 저장
-        chatService.saveMessage(request, jwtToken);
-
-        log.info("채널 메시지 저장 성공 : channelPk ={}, dmRoomPk = {}",
-                request.getChannelPk(), request.getDmRoomPk());
-        return ResponseEntity.ok("메시지가 성공적으로 저장되었습니다.");
-
-    }
-
     // 채널 최신 메시지 조회 (최초 로드)
     @GetMapping("/channel/{channelPk}/messages")
     public ResponseEntity<List<MessageResponse>> getLatestChannelMessages(


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> refactor/-remove-duplicate-message-save-api

<br/>

## 🥔 작업 내용

---

- WebSocket에서 메시지 전송 시 저장까지 처리하므로 중복되는 REST 저장 API 제거 (`POST /api/jv/chat/channel`)

<br/>

## 📸 스크린샷 or 영상

(선택사항)

## 💥 확인해주세요!

---

- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>