### PR TITLE
refactor(#이슈번호): UserStatusChangeResponse userPk를 userEmail로 변경

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatWebSocketController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatWebSocketController.java
@@ -204,7 +204,7 @@ public class ChatWebSocketController {
     @MessageMapping("/userstate/change")
     public void changeUserStatus(@Payload UserStatusChangeRequest request,
                                  SimpMessageHeaderAccessor headerAccessor) {
-        Integer userPk = null;
+        String userEmail = null;
         try {
             // JWT 토큰 검증 및 userPk 추출
             String jwtToken = extractJwtFromSession(headerAccessor);
@@ -212,14 +212,15 @@ public class ChatWebSocketController {
                 throw new RuntimeException("JWT 토큰을 찾을 수 없습니다.");
             }
 
-            userPk = extractUserPkFromToken(jwtToken);
+            userEmail = jwtTokenProvider.getUserEmailFromToken(jwtToken);
+            Integer userPk = extractUserPkFromToken(jwtToken);
 
             // 상태 변경
             userStateService.setUserStatus(userPk, request.getStatus());
 
             // 상태 변경 응답 생성
             UserStatusChangeResponse response = UserStatusChangeResponse.builder()
-                    .userPk(userPk)
+                    .userEmail(userEmail)
                     .status(request.getStatus())
                     .timestamp(System.currentTimeMillis())
                     .build();
@@ -228,20 +229,20 @@ public class ChatWebSocketController {
             if (request.getProjectPk() != null) {
                 String projectDestination = "/topic/project/" + request.getProjectPk() + "/userstate";
                 messagingTemplate.convertAndSend(projectDestination, response);
-                log.info("프로젝트 상태 변경 브로드캐스트: projectPk={}, userPk={}, status={}",
-                        request.getProjectPk(), userPk, request.getStatus());
+                log.info("프로젝트 상태 변경 브로드캐스트: projectPk={}, userEmail={}, status={}",
+                        request.getProjectPk(), userEmail, request.getStatus());
             }
 
             if (request.getDmRoomPk() != null) {
                 String dmDestination = "/topic/dm/" + request.getDmRoomPk() + "/userstate";
                 messagingTemplate.convertAndSend(dmDestination, response);
-                log.info("DM 상태 변경 브로드캐스트: dmRoomPk={}, userPk={}, status={}",
-                        request.getDmRoomPk(), userPk, request.getStatus());
+                log.info("DM 상태 변경 브로드캐스트: dmRoomPk={}, userEmail={}, status={}",
+                        request.getDmRoomPk(), userEmail, request.getStatus());
             }
 
         } catch (Exception e) {
-            log.error("사용자 상태 변경 실패: userPk={}, status={}",
-                    userPk, request.getStatus(), e);
+            log.error("사용자 상태 변경 실패: userEmail={}, status={}",
+                    userEmail, request.getStatus(), e);
         }
     }
 

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
@@ -52,11 +52,15 @@ public class UserStateController {
     public ResponseEntity<UserStatusChangeResponse> setCurrentUserStatus(
             @RequestBody UserStatusChangeRequestForRest request,
             HttpServletRequest httpRequest) {
-        Integer userPk = extractUserPkFromRequest(httpRequest);
+        String token = extractTokenFromCookie(httpRequest);
+        String userEmail = jwtTokenProvider.getUserEmailFromToken(token);
+        Integer userPk = userRepository.findUserPkByUserEmail(userEmail)
+                .orElseThrow(() -> new UnauthorizedException("사용자를 찾을 수 없습니다"));
+
         userStateService.setUserStatus(userPk, request.getStatus());
 
         UserStatusChangeResponse response = UserStatusChangeResponse.builder()
-                .userPk(userPk)
+                .userEmail(userEmail)
                 .status(request.getStatus())
                 .timestamp(System.currentTimeMillis())
                 .build();
@@ -104,7 +108,6 @@ public class UserStateController {
         List<DmRoomResponse> dmRooms = userStateService.getDmRoomsWithStatus(userPk);
         return ResponseEntity.ok(dmRooms);
     }
-
 
 
     /**

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/dto/UserStatusChangeResponse.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/dto/UserStatusChangeResponse.java
@@ -8,7 +8,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserStatusChangeResponse {
-    private Integer userPk;
+    private String userEmail;
     private UserStatus status;
     private Long timestamp;
 }


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> refactor/-userstate-response-replace-userPk-with-userEmail

<br/>

## 🥔 작업 내용

---

- UserStatusChangeResponse DTO 필드를 userPk(Integer) → userEmail(String)로 변경
- UserStateController: REST 상태 설정 응답에서 userEmail 사용
- ChatWebSocketController: WebSocket 상태 브로드캐스트 응답에서 userEmail 사용
- 프론트에 PK를 노출하지 않는 보안 방침에 맞춰 일관성 확보

<br/>

## 📸 스크린샷 or 영상

(선택사항)

## 💥 확인해주세요!

---

- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>