### PR TITLE
Feature/#186 dm room get by user api

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/dmroom/controller/DmRoomController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/dmroom/controller/DmRoomController.java
@@ -8,12 +8,10 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -41,9 +39,23 @@ public class DmRoomController {
     }
 
     /**
+     *
+     */
+    @GetMapping("/rooms/by-user")
+    public ResponseEntity<DmRoomCreateResponse> getDmRoomByUser(
+            @RequestParam String targetUserEmail,
+            HttpServletRequest httpRequest) {
+        String token = extractTokenFromCookie(httpRequest);
+        DmRoomCreateResponse response = dmRoomService.getDmRoomByUser(
+                targetUserEmail, token);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
      * 쿠키에서 access_token 추출
      * - 토큰 없으면 UnauthorizedException → 401
-     *
+     * <p>
      * TODO : 지금 이거 컨트롤러별로 쓰고 있는데 공용 유틸로 빼기
      */
     private String extractTokenFromCookie(HttpServletRequest request) {

--- a/spbackend/src/main/java/com/luminous/aurora/dmroom/controller/DmRoomController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/dmroom/controller/DmRoomController.java
@@ -8,7 +8,6 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -39,7 +38,9 @@ public class DmRoomController {
     }
 
     /**
-     *
+     * 특정 상대방과의 기존 DM방 조회
+     * - 존재하면 200 -> DM방 정보
+     * - 없으면 404
      */
     @GetMapping("/rooms/by-user")
     public ResponseEntity<DmRoomCreateResponse> getDmRoomByUser(
@@ -55,7 +56,7 @@ public class DmRoomController {
     /**
      * 쿠키에서 access_token 추출
      * - 토큰 없으면 UnauthorizedException → 401
-     * <p>
+     *
      * TODO : 지금 이거 컨트롤러별로 쓰고 있는데 공용 유틸로 빼기
      */
     private String extractTokenFromCookie(HttpServletRequest request) {

--- a/spbackend/src/main/java/com/luminous/aurora/dmroom/service/DmRoomService.java
+++ b/spbackend/src/main/java/com/luminous/aurora/dmroom/service/DmRoomService.java
@@ -5,4 +5,8 @@ import com.luminous.aurora.dmroom.dto.DmRoomCreateResponse;
 public interface DmRoomService {
     // DM 방 생성
     DmRoomCreateResponse createDmRoom(String targetUserEmail, String jwtToken);
+
+    // 특정 상대방과의 DM 방 조회
+    // 생성때와 같은 양식으로 주기때문에 CreateResponse 재활용
+    DmRoomCreateResponse getDmRoomByUser(String targetUserEmail, String jwtToken);
 }

--- a/spbackend/src/main/java/com/luminous/aurora/dmroom/service/DmRoomServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/dmroom/service/DmRoomServiceImpl.java
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class DmRoomServiceImpl implements DmRoomService{
+public class DmRoomServiceImpl implements DmRoomService {
 
     private final DmRoomRepository dmRoomRepository;
     private final DmMemberRepository dmMemberRepository;
@@ -30,10 +30,10 @@ public class DmRoomServiceImpl implements DmRoomService{
 
     /**
      * DM방 생성
-     *
+     * <p>
      * 호출되는 곳
      * - dmRoomController -> POST /api/jv/dm/rooms
-     *
+     * <p>
      * 처리 순서:
      * 1. JWT에서 요청자 이메일 추출 -> User 조회
      * 2. 자기 자신에게 DM 시도 시 -> 400 BadRequest
@@ -84,6 +84,41 @@ public class DmRoomServiceImpl implements DmRoomService{
                 dmRoom.getDmRoomPk(), myEmail, targetUserEmail);
 
         // 6. 응답
+        return DmRoomCreateResponse.builder()
+                .dmRoomPk(dmRoom.getDmRoomPk())
+                .targetUserEmail(targetUserEmail)
+                .targetUserName(targetUser.getUserName())
+                .targetUserProfileImage(targetUser.getProfileImagePath())
+                .build();
+
+    }
+
+    /**
+     * 특정 상대방과의 기존 DM 방 조회
+     * 호출 되는 곳 :
+     * - DmRoomController → GET /api/jv/dm/rooms/by-user
+     *
+     * 처리 순서:
+     * 1. JWT 에서 요청자 이메일 추출 -> Users 조회
+     * 2. targetUserEmail로 상대방 Users 조회 -> 없으면 404
+     * 3. 두 유저가 같은 DM 방에 있는지 확인 -> 없으면 404
+     * 4. DmRoomCreate 반환
+     *
+     */
+    @Override
+    public DmRoomCreateResponse getDmRoomByUser(String targetUserEmail, String jwtToken) {
+        String myEmail = jwtTokenProvider.getUserEmailFromToken(jwtToken);
+
+        Users myUser = userRepository.findByUserEmail(myEmail)
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+
+        Users targetUser = userRepository.findByUserEmail(targetUserEmail)
+                .orElseThrow(() -> new NotFoundException("해당 사용자를 찾을 수 없습니다."));
+
+        DmRoom dmRoom = dmMemberRepository.findExistingDmRoom(
+                myUser.getUserPk(), targetUser.getUserPk())
+                .orElseThrow(() -> new NotFoundException("해당 사용자와의 DM 방이 존재하지 않습니다."));
+
         return DmRoomCreateResponse.builder()
                 .dmRoomPk(dmRoom.getDmRoomPk())
                 .targetUserEmail(targetUserEmail)


### PR DESCRIPTION

# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> feature/-dm-room-get-by-user-api

<br/>

## 🥔 작업 내용

---

- DmRoomService에 getDmRoomByUser 메서드 추가 (기존 findExistingDmRoom 쿼리 재활용)
- DmRoomController에 GET /api/jv/dm/rooms/by-user 엔드포인트 추가
- 상대방 없으면 404, DM방 없으면 404 처리
- DmRoomCreateResponse DTO 재활용

<br/>

## 📸 스크린샷 or 영상

<img width="861" height="524" alt="image" src="https://github.com/user-attachments/assets/667a831b-e42c-41b6-bb02-43a5a20e2de3" />

## 💥 확인해주세요!

---

- [x] 모든 기능이 제대로 동작하는지 확인해주세요.
- [x] 컨벤션을 제대로 지켰는지 확인해주세요.
<br/>