### PR TITLE
Feature/#194 chat messages around and newer api

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
@@ -61,6 +61,19 @@ public class ChatController {
     }
 
     /**
+     * 채널 newer 메시지 조회 (messagePk 이후 최대 40개)
+     * GET /api/jv/chat/channel/{channelPk}/messages/newer?messagePk=
+     */
+    @GetMapping("/channel/{channelPk}/messages/newer")
+    public ResponseEntity<MessageListResponse> getNewerChannelMessages(@PathVariable Integer channelPk,
+                                                                       @RequestParam Long messagePk,
+                                                                       @CookieValue("access_token") String jwtToken) {
+        MessageListResponse response = chatService.getNewerMessage(channelPk, messagePk, jwtToken);
+        log.info("채널 newer 메시지 조회: channelPk = {}, messagePk = {}, count = {}", channelPk, messagePk, response.getMessages().size());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
      * DM방 최신 메시지 조회 (DM방 입장 시)
      * GET /api/jv/chat/dm/{dmRoomPk}/messages
      */

--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
@@ -46,6 +46,19 @@ public class ChatController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 채널 around 메시지 조회
+     * GET /api/jv/chat/channel/{channelPk}/messages/around
+     */
+    @GetMapping("/channel/{channelPk}/messages/around")
+    public ResponseEntity<MessageListResponse> getAroundChannelMessages(@PathVariable Integer channelPk,
+                                                                       @RequestParam Long messagePk,
+                                                                       @CookieValue("access_token") String jwtToken) {
+        MessageListResponse response = chatService.getAroundMessage(channelPk, messagePk, jwtToken);
+        log.info("채널 around 메시지 조회: channelPk = {}, messagePk = {}, count = {}",
+                channelPk, messagePk, response.getMessages().size());
+        return ResponseEntity.ok(response);
+    }
 
     /**
      * DM방 최신 메시지 조회 (DM방 입장 시)

--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
@@ -52,8 +52,8 @@ public class ChatController {
      */
     @GetMapping("/channel/{channelPk}/messages/around")
     public ResponseEntity<MessageListResponse> getAroundChannelMessages(@PathVariable Integer channelPk,
-                                                                       @RequestParam Long messagePk,
-                                                                       @CookieValue("access_token") String jwtToken) {
+                                                                        @RequestParam Long messagePk,
+                                                                        @CookieValue("access_token") String jwtToken) {
         MessageListResponse response = chatService.getAroundMessage(channelPk, messagePk, jwtToken);
         log.info("채널 around 메시지 조회: channelPk = {}, messagePk = {}, count = {}",
                 channelPk, messagePk, response.getMessages().size());
@@ -79,6 +79,19 @@ public class ChatController {
     public ResponseEntity<MessageListResponse> getOlderDmMessages(@PathVariable Integer dmRoomPk, @RequestParam LocalDateTime lastMessageTime, @CookieValue("access_token") String jwtToken) {
         MessageListResponse response = chatService.getOlderDmMessage(dmRoomPk, lastMessageTime, jwtToken);
         log.info("DM방 이전 메시지 조회 성공: dmRoomPk={}, messageCount={}, lastMessageTime={}", dmRoomPk, response.getMessages().size(), lastMessageTime);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * DM around 메시지 조회
+     * GET /api/jv/chat/dm/{dmRoomPk}/messages/around?messagePk=
+     */
+    @GetMapping("/dm/{dmRoomPk}/messages/around")
+    public ResponseEntity<MessageListResponse> getAroundDmMessages(@PathVariable Integer dmRoomPk,
+                                                                   @RequestParam Long messagePk,
+                                                                   @CookieValue("access_token") String jwtToken) {
+        MessageListResponse response = chatService.getAroundDmMessage(dmRoomPk, messagePk, jwtToken);
+        log.info("DM around 메시지 조회 성공: dmRoomPk = {}, messagePk = {}, count = {}", dmRoomPk, messagePk, response.getMessages().size());
         return ResponseEntity.ok(response);
     }
 }

--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
@@ -107,4 +107,17 @@ public class ChatController {
         log.info("DM around 메시지 조회 성공: dmRoomPk = {}, messagePk = {}, count = {}", dmRoomPk, messagePk, response.getMessages().size());
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * DM newer 메시지 조회 (messagePk 이후 최대 40개)
+     * GET /api/jv/chat/dm/{dmRoomPk}/messages/newer?messagePk=
+     */
+    @GetMapping("/dm/{dmRoomPk}/messages/newer")
+    public ResponseEntity<MessageListResponse> getNewerDmMessages(@PathVariable Integer dmRoomPk,
+                                                                  @RequestParam Long messagePk,
+                                                                  @CookieValue("access_token") String jwtToken) {
+        MessageListResponse response = chatService.getNewerDmMessage(dmRoomPk, messagePk, jwtToken);
+        log.info("DM newer 메시지 조회: dmRoomPk = {}, messagePk = {}, count = {}", dmRoomPk, messagePk, response.getMessages().size());
+        return ResponseEntity.ok(response);
+    }
 }

--- a/spbackend/src/main/java/com/luminous/aurora/chat/repository/MessageRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/repository/MessageRepository.java
@@ -76,6 +76,11 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
             "ORDER BY m.createdAt DESC LIMIT 1")
     Optional<Message> findLatestMessageInDmRoom(@Param("dmRoomPk") Integer dmRoomPk);
 
+    // DM newer 메시지 쿼리 (내가 마지막으로 본 메세지보다 이후 온 메시지 40개)
+    @Query("SELECT m FROM Message m WHERE m.dmRoomPk.dmRoomPk = :dmRoomPk AND m.messagePk > :afterMessagePk ORDER BY m.messagePk LIMIT 40")
+    List<Message> findDmMessagesNewerThanAfterPk(@Param("dmRoomPk") Integer dmRoomPk,
+                                                 @Param("afterMessagePk") Long afterMessagePk);
+
     // DM용 읽지 않은 메시지 개수 (내가 보낸것 제외)
     @Query("SELECT COUNT(m) FROM Message m " +
             "WHERE m.dmRoomPk.dmRoomPk = :dmRoomPk " +

--- a/spbackend/src/main/java/com/luminous/aurora/chat/repository/MessageRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/repository/MessageRepository.java
@@ -51,6 +51,11 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     List<Message> findChannelMessagesStrictlyNewerThan(@Param("channelPk") Integer channelPk,
                                                       @Param("anchorPk") Long anchorPk);
 
+    // 채널 newer 메시지 쿼리 (내가 마지막으로 본 메세지보다 이후 온 메시지 40개)
+    @Query("SELECT m FROM Message m WHERE m.channelPk.channelPk = :channelPk AND m.messagePk > :afterMessagePk ORDER BY m.messagePk LIMIT 40")
+    List<Message> findChannelMessagesNewerThanAfterPk(@Param("channelPk") Integer channelPk,
+                                                      @Param("afterMessagePk") Long afterMessagePk);
+
     // ================ DM around ==============
 
     // DM 방에서 기준 메시지 1건

--- a/spbackend/src/main/java/com/luminous/aurora/chat/repository/MessageRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/repository/MessageRepository.java
@@ -35,6 +35,23 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     // 채널에 메시지가 1개라도 있는지 확인 (안읽은 메시지 확인용 - lastReadMessage = null 이면 아직 하나도 안읽은건지, 진짜 메시지가 없는건지 체크)
     boolean existsByChannelPk_ChannelPk(Integer channelPk);
 
+
+    // 채널 around용 메서드 3개
+
+    // 1. 기준 메시지가 해당 채널에 있는지 확인하는 앵커
+    Optional<Message> findByMessagePkAndChannelPk_ChannelPk(Long messagePk, Integer channelPk);
+
+    // 2. 기준 보다 작은 Pk중 최대 20개 - 최신쪽 부터 가져온 뒤 서비스에서 리스트를 뒤집어 시간/pk 오름차순으로 맞춘다.
+    @Query("SELECT m FROM Message m WHERE m.channelPk.channelPk = :channelPk AND m.messagePk < :anchorPk ORDER BY m.messagePk DESC LIMIT 20")
+    List<Message> findChannelMessagesStrictlyOlderThan(@Param("channelPk") Integer channelPk,
+                                                       @Param("anchorPk") Long anchorPk);
+
+    // 3. 기준보다 큰 Pk 중 최대 20개 - 오름차순 그대로
+    @Query("SELECT m FROM Message m WHERE m.channelPk.channelPk = :channelPk AND m.messagePk > :anchorPk ORDER BY m.messagePk LIMIT 20")
+    List<Message> findChannelMessagesStrictlyNewerThan(@Param("channelPk") Integer channelPk,
+                                                      @Param("anchorPk") Long anchorPk);
+
+
     // DM방의 가장 최신 메시지 1개 조회(마지막 메시지 미리보기용)
     @Query("SELECT m FROM Message m " +
             "WHERE m.dmRoomPk.dmRoomPk = :dmRoomPk " +

--- a/spbackend/src/main/java/com/luminous/aurora/chat/repository/MessageRepository.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/repository/MessageRepository.java
@@ -51,6 +51,19 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     List<Message> findChannelMessagesStrictlyNewerThan(@Param("channelPk") Integer channelPk,
                                                       @Param("anchorPk") Long anchorPk);
 
+    // ================ DM around ==============
+
+    // DM 방에서 기준 메시지 1건
+    Optional<Message> findByMessagePkAndDmRoomPk_DmRoomPk(Long messagePk, Integer dmRoomPk);
+
+    // 기준 messagePk보다 작은 PK 중, 큰 쪽부터 최대 20개 (DESC). 서비스에서 reverse 하면 오름차순.
+    @Query("SELECT m FROM Message m WHERE m.dmRoomPk.dmRoomPk = :dmRoomPk AND m.messagePk < :anchorPk ORDER BY m.messagePk DESC LIMIT 20")
+    List<Message> findDmMessagesStrictlyOlderThan(@Param("dmRoomPk") Integer dmRoomPk,
+                                                  @Param("anchorPk") Long anchorPk);
+    // 기준 messagePk보다 큰 PK 중 오름차순 최대 20개
+    @Query("SELECT m FROM Message m WHERE m.dmRoomPk.dmRoomPk = :dmRoomPk AND m.messagePk > :anchorPk ORDER BY m.messagePk LIMIT 20")
+    List<Message> findDmMessagesStrictlyNewerThan(@Param("dmRoomPk") Integer dmRoomPk,
+                                                  @Param("anchorPk") Long anchorPk);
 
     // DM방의 가장 최신 메시지 1개 조회(마지막 메시지 미리보기용)
     @Query("SELECT m FROM Message m " +

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
@@ -35,6 +35,9 @@ public interface ChatService {
     // 채널별 이전 메시지 조회 (스크롤 시)
     MessageListResponse getOlderMessage(Integer channelPk, LocalDateTime lastMessageTime, String jwtToken);
 
+    // 채널: 기준 messagePk 주변 메시지 조회 (이전 20 + 기준 + 이후 20, 최대 41개)
+    MessageListResponse getAroundMessage(Integer channelPk, Long messagePk, String jwtToken);
+
     // DM 방별 최신 메시지 조회
     MessageListResponse getLatestDmMessage(Integer dmRoomPk, String jwtToken);
 

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
@@ -44,6 +44,9 @@ public interface ChatService {
     // DM 방별 이전 메시지 조회 (스크롤 시)
     MessageListResponse getOlderDmMessage(Integer dmRoomPk, LocalDateTime lastMessageTime, String jwtToken);
 
+    // DM : 기준 messagePk 주변 메시지 조회 (이전 20 + 기준 + 이후 20, 최대 41개)
+    MessageListResponse getAroundDmMessage(Integer dmRoomPk, Long messagePk, String jwtToken);
+
     // 채널 안읽은 메시지 표시용
     void markChannelAsRead(Integer channelPk, Long messagePk, String jwtToken);
 

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
@@ -38,6 +38,9 @@ public interface ChatService {
     // 채널: 기준 messagePk 주변 메시지 조회 (이전 20 + 기준 + 이후 20, 최대 41개)
     MessageListResponse getAroundMessage(Integer channelPk, Long messagePk, String jwtToken);
 
+    // 채널: 기준 messagePk 보다 이후에 온 메시지 40개 오름차순(newer 전용), 기준 메시지 미포함
+    MessageListResponse getNewerMessage(Integer channelPk, Long afterMessagePk, String jwtToken);
+
     // DM 방별 최신 메시지 조회
     MessageListResponse getLatestDmMessage(Integer dmRoomPk, String jwtToken);
 

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
@@ -50,6 +50,9 @@ public interface ChatService {
     // DM : 기준 messagePk 주변 메시지 조회 (이전 20 + 기준 + 이후 20, 최대 41개)
     MessageListResponse getAroundDmMessage(Integer dmRoomPk, Long messagePk, String jwtToken);
 
+    // DM : 기준 messagePk 보다 이후에 온 메시지 40개 오름차순(newer 전용), 기준 메시지 미포함
+    MessageListResponse getNewerDmMessage(Integer dmRoomPk, Long afterMessagePk, String jwtToken);
+
     // 채널 안읽은 메시지 표시용
     void markChannelAsRead(Integer channelPk, Long messagePk, String jwtToken);
 

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
@@ -371,6 +371,64 @@ public class ChatServiceImpl implements ChatService {
     }
 
     /**
+     * DM방의 특정 메시지 기준 주변 메시지 조회 (딥링크·검색 결과 포커스 등)
+     * <p>
+     * 기준 messagePk보다 작은 PK 최대 20개 + 기준 1개 + 큰 PK 최대 20개를 합쳐
+     * PK 오름차순으로 반환한다. (최대 41개)
+     *
+     * @param dmRoomPk - 조회할 DM방 PK
+     * @param messagePk - 기준이 되는 메시지 PK (해당 DM방 소속이어야 함)
+     * @param jwtToken - 사용자 인증 토큰
+     * @return MessageListResponse - lastReadMessagePk + 메시지 목록
+     * <p>
+     * 호출되는 곳:
+     * - ChatController (REST API) → GET /api/jv/chat/dm/{dmRoomPk}/messages/around
+     * <p>
+     * 처리 순서:
+     * 1. JWT에서 userPk 추출
+     * 2. DM방 접근 권한 검증
+     * 3. 기준 메시지가 해당 DM방에 존재하는지 확인
+     * 4. 기준보다 이전/이후 메시지 각각 조회 후 오름차순으로 병합
+     * 5. Message → MessageResponse 변환
+     */
+    @Override
+    public MessageListResponse getAroundDmMessage(Integer dmRoomPk, Long messagePk, String jwtToken) {
+        try {
+            Integer userPk = getUserPkFromToken(jwtToken);
+            validateDmRoomAccess(dmRoomPk, userPk);
+
+            Message anchor = messageRepository.findByMessagePkAndDmRoomPk_DmRoomPk(messagePk, dmRoomPk)
+                    .orElseThrow(() -> new NotFoundException("기준 메시지가 해당 DM 방에 없습니다."));
+
+            List<Message> older = messageRepository.findDmMessagesStrictlyOlderThan(dmRoomPk, messagePk);
+            java.util.Collections.reverse(older);
+
+            List<Message> newer = messageRepository.findDmMessagesStrictlyNewerThan(dmRoomPk, messagePk);
+
+            ArrayList<Message> combined = new ArrayList<>(older.size() + 1 + newer.size());
+            combined.addAll(older);
+            combined.add(anchor);
+            combined.addAll(newer);
+
+            List<MessageResponse> messageResponses = combined.stream()
+                    .map(this::convertToMessageResponse)
+                    .toList();
+
+            Long lastReadMessagePk = getDmLastReadMessagePk(dmRoomPk, userPk);
+
+            return MessageListResponse.builder()
+                    .lastReadMessagePk(lastReadMessagePk)
+                    .messages(messageResponses)
+                    .build();
+        } catch (ForbiddenException | NotFoundException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("DM around 메시지 조회 실패 : {}", e.getMessage());
+            throw new InternalServerErrorException("DM around 메시지 조회 중 서버 오류가 발생했습니다. : "+ e.getMessage());
+        }
+    }
+
+    /**
      * 여러 채널의 안 읽은 메시지 존재 여부 일괄 조회
      *
      * @param channelPks - 조회할 채널 PK 목록

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -230,6 +231,66 @@ public class ChatServiceImpl implements ChatService {
             throw new InternalServerErrorException("이전 메시지 조회 중 서버 오류가 발생했습니다. " + e.getMessage());
         }
     }
+
+    /**
+     * 채널의 특정 메시지 기준 주변 메시지 조회 (안읽은 메시지 중간에 들어오기 + 검색 메시지 주변메시지에 쓸듯)
+     * <p>
+     * 기준 messagePk 보다 작은 Pk 최대 20개 + 기준 1개 + 큰 20개를 합쳐
+     * 시간(pk) 오름차순으로 반환한다(최대 41개)
+     *
+     * @param channelPk 조회할 채널 Pk
+     * @param messagePk 기준이 되는 메시지 Pk (해당 채널 소속이어야 함)
+     * @param jwtToken 사용자 인증 토큰
+     * @return MessageListResponse - LastReadMessagePk + 메시지 목록
+     * <p>
+     * 호출 되는 곳
+     * - ChatController (REST API) -> GET /api/jv/chat/channel/{channelPk}/messages/around
+     * <p>
+     * 처리 순서
+     * 1. jwt에서 userPk 추출
+     * 2. 채널 접근 권한 검증
+     * 3. 기준 메시지가 해당 채널에 존재하는지 확인
+     * 4. 기준보다 이전/이후 메시지 각각 조회 후 오름차순으로 병합
+     * 5. Message -> MessageResponse 변환
+     */
+    @Override
+    public MessageListResponse getAroundMessage(Integer channelPk, Long messagePk, String jwtToken) {
+        try {
+            Integer userPk = getUserPkFromToken(jwtToken);
+            validateChannelAccess(channelPk, userPk);
+
+            Message anchor = messageRepository.findByMessagePkAndChannelPk_ChannelPk(messagePk, channelPk)
+                    .orElseThrow(() -> new NotFoundException("기준메시지가 해당 채널에 없음"));
+
+            List<Message> older = messageRepository.findChannelMessagesStrictlyOlderThan(channelPk, messagePk);
+            java.util.Collections.reverse(older);
+
+            List<Message> newer = messageRepository.findChannelMessagesStrictlyNewerThan(channelPk, messagePk);
+
+            ArrayList<Message> combined = new ArrayList<>(older.size() + 1 + newer.size());
+
+            combined.addAll(older);
+            combined.add(anchor);
+            combined.addAll(newer);
+
+            Long lastReadMessagePk = getChannelLastReadMessagePk(channelPk, userPk);
+
+            List<MessageResponse> messageResponse = combined.stream()
+                    .map(this::convertToMessageResponse)
+                    .toList();
+
+            return MessageListResponse.builder()
+                    .lastReadMessagePk(lastReadMessagePk)
+                    .messages(messageResponse)
+                    .build();
+        } catch (ForbiddenException | NotFoundException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("채널 around 메시지 조회 실패 : {}", e.getMessage());
+            throw new InternalServerErrorException("채널 around 메시지 조회 중 서버 오류가 발생 했습니다 : " + e.getMessage());
+        }
+    }
+
 
     /**
      * DM방의 최신 메시지 40개 조회 (처음 DM방 입장 시)

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
@@ -24,6 +24,7 @@ import com.luminous.aurora.member.repository.DmMemberRepository;
 import com.luminous.aurora.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -291,6 +292,55 @@ public class ChatServiceImpl implements ChatService {
         }
     }
 
+    /**
+     * 채널에서 특정 메시지 이후(더 새로운) 메시지 조회
+     * <p>
+     * afterMessagePk보다 큰 message_pk를 가진 메시지를 오름차순으로 최대 40개 반환한다.
+     * 기준 메시지(afterMessagePk)는 결과에 포함하지 않는다.
+     *
+     * @param channelPk - 조회할 채널 PK
+     * @param afterMessagePk - 커서로 쓰는 메시지 PK (해당 채널에 존재해야 함)
+     * @param jwtToken - 사용자 인증 토큰
+     * @return MessageListResponse - lastReadMessagePk + 메시지 목록
+     * <p>
+     * 호출되는 곳:
+     * - ChatController (REST API) → GET /api/jv/chat/channel/{channelPk}/messages/newer
+     * <p>
+     * 처리 순서:
+     * 1. JWT에서 userPk 추출
+     * 2. 채널 접근 권한 검증
+     * 3. 커서 메시지가 해당 채널에 존재하는지 확인
+     * 4. 이후 메시지 최대 40개 조회
+     * 5. Message → MessageResponse 변환
+     */
+    @Override
+    public MessageListResponse getNewerMessage(Integer channelPk, Long afterMessagePk, String jwtToken) {
+        try {
+            Integer userPk = getUserPkFromToken(jwtToken);
+            validateChannelAccess(channelPk, userPk);
+
+            messageRepository.findByMessagePkAndChannelPk_ChannelPk(afterMessagePk, channelPk)
+                    .orElseThrow(() -> new NotFoundException("기준 메시지가 해당 채널에 없음"));
+
+            List<Message> messages = messageRepository.findChannelMessagesNewerThanAfterPk(channelPk, afterMessagePk);
+            List<MessageResponse> messageResponses = messages.stream()
+                    .map(this::convertToMessageResponse)
+                    .toList();
+
+            Long lastReadMessagePk = getChannelLastReadMessagePk(channelPk, userPk);
+
+            return MessageListResponse.builder()
+                    .lastReadMessagePk(lastReadMessagePk)
+                    .messages(messageResponses)
+                    .build();
+        } catch (ForbiddenException | NotFoundException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("채널 newer 메시지 조회 실패 : {}", e.getMessage());
+            throw new InternalServerErrorException("채널 newer 메시지 조회 중 서버 오류가 발생했습니다. : " + e.getMessage());
+        }
+    }
+
 
     /**
      * DM방의 최신 메시지 40개 조회 (처음 DM방 입장 시)
@@ -424,7 +474,7 @@ public class ChatServiceImpl implements ChatService {
             throw e;
         } catch (Exception e) {
             log.error("DM around 메시지 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("DM around 메시지 조회 중 서버 오류가 발생했습니다. : "+ e.getMessage());
+            throw new InternalServerErrorException("DM around 메시지 조회 중 서버 오류가 발생했습니다. : " + e.getMessage());
         }
     }
 

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
@@ -479,6 +479,56 @@ public class ChatServiceImpl implements ChatService {
     }
 
     /**
+     * DM방에서 특정 메시지 이후(더 새로운) 메시지 조회
+     * <p>
+     * afterMessagePk보다 큰 message_pk를 가진 메시지를 오름차순으로 최대 40개 반환한다.
+     * 기준 메시지(afterMessagePk)는 결과에 포함하지 않는다.
+     *
+     * @param dmRoomPk - 조회할 DM방 PK
+     * @param afterMessagePk - 커서로 쓰는 메시지 PK (해당 DM방에 존재해야 함)
+     * @param jwtToken - 사용자 인증 토큰
+     * @return MessageListResponse - lastReadMessagePk + 메시지 목록
+     * <p>
+     * 호출되는 곳:
+     * - ChatController (REST API) → GET /api/jv/chat/dm/{dmRoomPk}/messages/newer
+     * <p>
+     * 처리 순서:
+     * 1. JWT에서 userPk 추출
+     * 2. DM방 접근 권한 검증
+     * 3. 커서 메시지가 해당 DM방에 존재하는지 확인
+     * 4. 이후 메시지 최대 40개 조회
+     * 5. Message → MessageResponse 변환
+     */
+    @Override
+    public MessageListResponse getNewerDmMessage(Integer dmRoomPk, Long afterMessagePk, String jwtToken) {
+        try {
+            Integer userPk = getUserPkFromToken(jwtToken);
+            validateDmRoomAccess(dmRoomPk, userPk);
+
+            messageRepository.findByMessagePkAndDmRoomPk_DmRoomPk(afterMessagePk, dmRoomPk)
+                    .orElseThrow(() -> new NotFoundException("기준 메시지가 해당 DM 방에 없습니다."));
+
+            List<Message> messages = messageRepository.findDmMessagesNewerThanAfterPk(dmRoomPk, afterMessagePk);
+            List<MessageResponse> messageResponses = messages.stream()
+                    .map(this::convertToMessageResponse)
+                    .toList();
+
+            Long lastReadMessagePk = getDmLastReadMessagePk(dmRoomPk, userPk);
+
+            return MessageListResponse.builder()
+                    .lastReadMessagePk(lastReadMessagePk)
+                    .messages(messageResponses)
+                    .build();
+
+        } catch (ForbiddenException | NotFoundException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("DM newer 메시지 조회 실패 : {}", e.getMessage());
+            throw new InternalServerErrorException("DM newer 메시지 조회 중 서버 오류가 발생했습니다. : " + e.getMessage());
+        }
+    }
+
+    /**
      * 여러 채널의 안 읽은 메시지 존재 여부 일괄 조회
      *
      * @param channelPks - 조회할 채널 PK 목록


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> feature/#194-chat-messages-around-newer

<br/>

## 🥔 작업 내용

---

- 채널·DM에 **기준 `messagePk` 주변 메시지 조회(around)** REST API를 추가했다. 이전 구간 최대 20건 + 기준 1건 + 이후 구간 최대 20건(최대 41건)이며, 응답은 기존과 동일하게 `MessageListResponse`임.
- 채널·DM에 **기준 `messagePk` 이후 메시지 조회(newer)** REST API를 추가. 기준 PK는 제외하고 이후 메시지를 PK 오름차순으로 최대 40건까지 반환하며, 기준 메시지가 해당 채널/DM에 없으면 404로 처리.
- `MessageRepository`에 around·newer용 JPQL 조회 메서드를 추가하고, `ChatService` / `ChatServiceImpl`에서 권한 검증·목록 병합·DTO 변환을 수행.
- `ChatController`에 다음 엔드포인트를 연결: `GET .../channel/{channelPk}/messages/around|newer`, `GET .../dm/{dmRoomPk}/messages/around|newer` (쿼리 `messagePk`).
- 워크스페이스 규칙 문서 `.cursor/rules/conventions.mdc`에 Chat API 표·API 명세 예시(200 `MessageListResponse`, 오류 `ErrorResponseDto` 예시)를 반영.

<br/>