### PR TITLE
Refactor/#179 ex server refactoring

### DIFF
--- a/exbackend/src/domain/channel/repositories/channel-member.repository.ts
+++ b/exbackend/src/domain/channel/repositories/channel-member.repository.ts
@@ -55,4 +55,7 @@ export abstract class ChannelMemberRepository {
 
   // 유저가 가입중인 서버의 모든 프로젝트의 모든 채널에서 나가기 처리
   abstract deactivateUserInServer(manager: EntityManager, serverPk: number, userPk: number): Promise<void>;
+
+  // 특정 프로젝트의 모든 Public 채널에 유저를 일괄 가입 처리
+  abstract addAllToPublicChannelsInProject(manager: EntityManager, projectPk: number, userPk: number): Promise<void>;
 }

--- a/exbackend/src/domain/channel/repositories/repositoryImpl/typeorm-channel-member.repository.ts
+++ b/exbackend/src/domain/channel/repositories/repositoryImpl/typeorm-channel-member.repository.ts
@@ -4,7 +4,7 @@ import { Repository, FindOptionsWhere, Brackets } from "typeorm";
 import { ChannelMember } from "../../entities/channel-member.entity";
 import { ChannelMemberRepository } from "../channel-member.repository";
 import { EntityManager } from "typeorm";
-import { MemberStatus } from "src/common/enums";
+import { MemberStatus, MemberRole } from "src/common/enums";
 
 @Injectable()
 export class TypeOrmChannelMemberRepository extends ChannelMemberRepository {
@@ -141,5 +141,33 @@ export class TypeOrmChannelMemberRepository extends ChannelMemberRepository {
       .andWhere('cStatus = :status', { status: MemberStatus.ACTIVE })
       .andWhere('channelPk IN (SELECT c.channel_pk FROM channel c JOIN project p ON c.project_pk = p.project_pk WHERE p.server_pk = :serverPk)', { serverPk })
       .execute();
+  }
+
+  // 특정 프로젝트의 모든 Public 채널에 유저를 일괄 가입 처리
+  async addAllToPublicChannelsInProject(manager: EntityManager, projectPk: number, userPk: number): Promise<void> {
+    // 1. 해당 프로젝트의 모든 PUBLIC 채널 중 유저가 아직 가입하지 않은 채널 PK 목록 조회
+    const subQuery = manager
+      .createQueryBuilder()
+      .select('c.channel_pk')
+      .from('channel', 'c')
+      .leftJoin('channel_member', 'cm', 'cm.channel_pk = c.channel_pk AND cm.user_pk = :userPk', { userPk })
+      .where('c.project_pk = :projectPk', { projectPk })
+      .andWhere('c.access_type = :accessType', { accessType: 'PUBLIC' })
+      .andWhere('c.is_deleted_channel = :isDeleted', { isDeleted: false })
+      .andWhere('cm.channel_member_pk IS NULL');
+
+    const channels = await subQuery.getRawMany();
+    
+    if (channels.length === 0) return;
+
+    // 2. 가입 처리
+    const newMembers = channels.map(c => ({
+      channelPk: c.channel_pk,
+      userPk: userPk,
+      cStatus: MemberStatus.ACTIVE,
+      channelRole: MemberRole.MEMBER,
+    }));
+
+    await manager.getRepository(ChannelMember).insert(newMembers);
   }
 }

--- a/exbackend/src/domain/project/project.module.ts
+++ b/exbackend/src/domain/project/project.module.ts
@@ -63,7 +63,9 @@ import { ChannelModule } from '../channel/channel.module';
   exports: [
     ProjectService,
     ProjectMemberService,
-    ProjectNotificationService
+    ProjectNotificationService,
+    ProjectRepository,
+    ProjectMemberRepository,
   ],
 })
 export class ProjectModule {}

--- a/exbackend/src/domain/project/repositories/project-member.repository.ts
+++ b/exbackend/src/domain/project/repositories/project-member.repository.ts
@@ -41,4 +41,7 @@ export abstract class ProjectMemberRepository {
 
   // 특정 서버의 모든 프로젝트 멤버 나가기 처리
   abstract deactivateAllByServer(manager: EntityManager, serverPk: number): Promise<void>;
+
+  // 프로젝트 멤버 저장(manager 넘기는 용)
+  abstract addMember(manager: EntityManager, projectPk: number, userPk: number): Promise<void>;
 }

--- a/exbackend/src/domain/project/repositories/repositoriesImpl/typeorm-project-member.repository.ts
+++ b/exbackend/src/domain/project/repositories/repositoriesImpl/typeorm-project-member.repository.ts
@@ -129,4 +129,23 @@ export class TypeOrmProjectMemberRepository extends ProjectMemberRepository {
       .andWhere('projectPk IN (SELECT project_pk FROM project WHERE server_pk = :serverPk)', { serverPk })
       .execute();
   }
+
+  // 프로젝트 멤버 저장(Manager를 넘겨서 트랜잭션 안끊기게 하는 메서드)
+  async addMember(manager: EntityManager, projectPk: number, userPk: number): Promise<void> {
+    const repo = manager.getRepository(ProjectMember);
+
+    const existing = await repo.findOne({ where: { projectPk, userPk } });
+
+    if (!existing) {
+      await repo.save({
+        projectPk,
+        userPk,
+        pStatus: MemberStatus.ACTIVE,
+        projectRole: MemberRole.MEMBER,
+      })
+    } else if (existing.pStatus !== MemberStatus.ACTIVE) {
+      existing.pStatus = MemberStatus.ACTIVE;
+      await repo.save(existing);
+    }
+  }
 }

--- a/exbackend/src/domain/user/user.module.ts
+++ b/exbackend/src/domain/user/user.module.ts
@@ -30,6 +30,6 @@ import { TypeOrmUserRepository } from './repositories/repositoryImpl/typeorm-use
       useClass: UserPopulationInterceptor,
     }
   ],
-  exports: [UserService], 
+  exports: [UserService, UserRepository], 
 })
 export class UserModule {}


### PR DESCRIPTION
# 🐿️ Merge Requests
## 🪵 작업 브랜치
---
> refactor/#179-ex-server-refactoring

<br/>

## 🥔 작업 내용
---

- server service에서 서버 나가기, 서버 가입 시 "일반" 프로젝트의 모든 public 채널 가입시키는 로직을 직접 처리하고 있던 걸 리포지토리 단으로 분리
    - 서비스 단에서 트랜잭션 처리 없이 서버 나가기 하던 중 중간에 오류가 생겼을 때 프로젝트, 채널에는 그 사람이 남아있는 데이터 불일치가 일어남
    - 트랜잭션 처리함으로써 한꺼번에 반영되던가 아니면 롤백하여 데이터 불일치를 방지 
- 리팩토링 하면서 필요해진 project, user 모듈 추가

<br/>

## 📸 스크린샷 or 영상
(선택사항)
---


## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>