### PR TITLE
fix(#200): 서버 생성 시 삭제되었던 서버랑 같은 url로 다시 만들 수 없던 문제 수정

### DIFF
--- a/exbackend/src/domain/server/services/servicesImpl/server.service.impl.ts
+++ b/exbackend/src/domain/server/services/servicesImpl/server.service.impl.ts
@@ -52,7 +52,7 @@ export class ServerServiceImpl extends ServerService {
     }
 
     // 2. 서버 생성
-    const isExistServer = await this.serverRepository.findOne({ serverUrl: createServerDto.serverUrl });
+    const isExistServer = await this.serverRepository.findOne({ serverUrl: createServerDto.serverUrl, isDeletedServer: false });
 
     if (isExistServer) throw new ConflictException(`이미 중복된 URL ${createServerDto.serverUrl}이 존재합니다.`);
 


### PR DESCRIPTION
# 🐿️ Merge Requests
## 🪵 작업 브랜치
---
> fix/#200-fix-create-same-server

<br/>

## 🥔 작업 내용
---

- 서버 생성 시 이미 사용 중인 url인지 검증하는 부분에서 그 서버가 삭제 되었는지 여부를 같이 검색하는 조건이 빠졌음
- url 과 삭제 여부를 같이 조건에 넣도록 수정


<br/>

## 📸 스크린샷 or 영상
(선택사항)
---


## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>