### PR TITLE
fix(#205): 참가하지 않은 프로젝트의 공개 채널도 모두 불러와지는 문제 수정

### DIFF
--- a/exbackend/src/domain/channel/repositories/repositoryImpl/typeorm-channel.repository.ts
+++ b/exbackend/src/domain/channel/repositories/repositoryImpl/typeorm-channel.repository.ts
@@ -1,9 +1,9 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository, Brackets } from "typeorm";
+import { Repository } from "typeorm";
 import { Channel } from "../../entities/channel.entity";
 import { ChannelRepository } from "../channel.repository";
-import { ChannelKind, AccessType } from "src/common/enums";
+import { ChannelKind, AccessType, MemberStatus } from "../../../../common/enums";
 import { EntityManager } from "typeorm";
 
 @Injectable()
@@ -39,25 +39,15 @@ export class TypeOrmChannelRepository extends ChannelRepository {
 
     return this.channelRepository
       .createQueryBuilder('channel')
-      .leftJoinAndSelect('channel.channelMembers', 'channelMember')
+      .innerJoinAndSelect(
+        'channel.channelMembers', 
+        'channelMember',
+        'channelMember.userPk = :userPk AND channelMember.cStatus = :active',
+        { userPk, active: MemberStatus.ACTIVE }
+      )
       .where('channel.projectPk = :projectPk', { projectPk })
       .andWhere('channel.isDeletedChannel = false')
-      .andWhere(
-        // '(channel.accessType = \'PUBLIC\' OR (channel.accessType = \'PRIVATE\' AND channelMember.userPk = :userPk AND channelMember.cStatus = :activeStatus))',
-        //   { userPk: userPk, activeStatus: 'Active' },
-        new Brackets((qb) => {
-          qb.where('channel.accessType = :public', {public: 'PUBLIC'})
-            .orWhere(
-              '(channel.accessType = :private AND channelMember.userPk = :userPk AND channelMember.cStatus = :activeStatus)', 
-              { private: 'PRIVATE', userPk, activeStatus: 'Active' },
-            );
-        })
-      ).getMany();
-      // Brackets -->TypeORM의 QueryBuilder에서 SQL의 '괄호 ( )'를 묶어주는 도구
-      // 쓰는 이유
-      // 1. 가독성: 문자열이 너무 길어지면 \' 같은 이스케이프 문자가 많아져서 읽기 힘듬
-      // 2. 유연성: if 문에 따라 괄호 안의 조건을 동적으로 추가하거나 뺄 때 Brackets가 훨씬 편함
-      // 3. 안전성: 실수로 괄호를 덜 닫는 등의 실수를 방지함
+      .getMany();
   }
 
   async findAccessibleChannels(
@@ -65,16 +55,13 @@ export class TypeOrmChannelRepository extends ChannelRepository {
   ): Promise<Channel[]> {
     return this.channelRepository
       .createQueryBuilder('channel')
-      .leftJoinAndSelect('channel.channelMembers', 'channelMember', 'channelMember.userPk = :userPk', { userPk })
+      .innerJoinAndSelect(
+        'channel.channelMembers', 
+        'channelMember', 
+        'channelMember.userPk = :userPk AND channelMember.cStatus = :active', 
+        { userPk, active: MemberStatus.ACTIVE })
       .where('channel.isDeletedChannel = false')
-      .andWhere(
-        new Brackets((qb) => {
-          qb.where('channel.accessType = :public', { public: 'PUBLIC' })
-            .orWhere('channelMember.userPk = :userPk AND channelMember.cStatus = :active', 
-              { userPk, active: 'Active' }
-            );
-        })
-      ).getMany();
+      .getMany();
   }
 
   async findPublicChannels(projectPk: number): Promise<Channel[]> {


### PR DESCRIPTION
# 🐿️ Merge Requests
## 🪵 작업 브랜치
---
> fix/#205-get-user-all-channels

<br/>

## 🥔 작업 내용
---

- 기존 로직 left join -> 멤버에 속하든 속하지 않든 모든 채널을 가져옴(전제 조건이 틀림)
- 수정 inner join -> 멤버로 속한 채널만 가져오도록 필터링(public은 자동으로 모든 멤버 다 가입)
- 리터럴 -> enum으로 변경

<br/>

## 📸 스크린샷 or 영상
(선택사항)
---


## 💥 확인해주세요!
---
- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>