### PR TITLE
Refactor/#209 chat older response messages only

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
@@ -14,8 +14,8 @@ import java.time.LocalDateTime;
  * 메시지 조회 REST API 컨트롤러
  * <p>
  * 채널/DM 메시지 목록을 조회하는 REST API.
- * 모든 응답은 MessageListResponse로 래핑되어
- * lastReadMessagePk(읽음 위치)와 messages(메시지 목록)를 함께 반환함.
+ * 최신·around·newer 등은 {@link MessageListResponse}(읽음 위치 + 목록),
+ * 과거 무한 스크롤용 {@code .../messages/older} 는 {@link MessagesOnlyResponse}(목록만)을 반환한다.
  */
 @Slf4j
 @RestController

--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.luminous.aurora.chat.controller;
 
 import com.luminous.aurora.chat.dto.MessageListResponse;
+import com.luminous.aurora.chat.dto.MessagesOnlyResponse;
 import com.luminous.aurora.chat.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,8 +41,8 @@ public class ChatController {
      * GET /api/jv/chat/channel/{channelPk}/messages/older
      */
     @GetMapping("/channel/{channelPk}/messages/older")
-    public ResponseEntity<MessageListResponse> getOlderChannelMessages(@PathVariable Integer channelPk, @RequestParam LocalDateTime lastMessageTime, @CookieValue("access_token") String jwtToken) {
-        MessageListResponse response = chatService.getOlderMessage(channelPk, lastMessageTime, jwtToken);
+    public ResponseEntity<MessagesOnlyResponse> getOlderChannelMessages(@PathVariable Integer channelPk, @RequestParam LocalDateTime lastMessageTime, @CookieValue("access_token") String jwtToken) {
+        MessagesOnlyResponse response = chatService.getOlderMessage(channelPk, lastMessageTime, jwtToken);
         log.info("채널 이전 메시지 조회 성공: channelPk={}, messageCount={}, lastMessageTime={}", channelPk, response.getMessages().size(), lastMessageTime);
         return ResponseEntity.ok(response);
     }
@@ -89,8 +90,8 @@ public class ChatController {
      * GET /api/jv/chat/dm/{dmRoomPk}/messages/older
      */
     @GetMapping("/dm/{dmRoomPk}/messages/older")
-    public ResponseEntity<MessageListResponse> getOlderDmMessages(@PathVariable Integer dmRoomPk, @RequestParam LocalDateTime lastMessageTime, @CookieValue("access_token") String jwtToken) {
-        MessageListResponse response = chatService.getOlderDmMessage(dmRoomPk, lastMessageTime, jwtToken);
+    public ResponseEntity<MessagesOnlyResponse> getOlderDmMessages(@PathVariable Integer dmRoomPk, @RequestParam LocalDateTime lastMessageTime, @CookieValue("access_token") String jwtToken) {
+        MessagesOnlyResponse response = chatService.getOlderDmMessage(dmRoomPk, lastMessageTime, jwtToken);
         log.info("DM방 이전 메시지 조회 성공: dmRoomPk={}, messageCount={}, lastMessageTime={}", dmRoomPk, response.getMessages().size(), lastMessageTime);
         return ResponseEntity.ok(response);
     }

--- a/spbackend/src/main/java/com/luminous/aurora/chat/dto/MessagesOnlyResponse.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/dto/MessagesOnlyResponse.java
@@ -1,0 +1,16 @@
+package com.luminous.aurora.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MessagesOnlyResponse {
+    private List<MessageResponse> messages;
+}

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
@@ -3,6 +3,7 @@ package com.luminous.aurora.chat.service;
 import com.luminous.aurora.chat.dto.MessageListResponse;
 import com.luminous.aurora.chat.dto.MessageRequest;
 import com.luminous.aurora.chat.dto.MessageResponse;
+import com.luminous.aurora.chat.dto.MessagesOnlyResponse;
 import com.luminous.aurora.chat.entity.Message;
 import com.luminous.aurora.internal.dto.ChannelUnreadResponse;
 
@@ -33,7 +34,7 @@ public interface ChatService {
     MessageListResponse getLatestMessage(Integer channelPk, String jwtToken);
 
     // 채널별 이전 메시지 조회 (스크롤 시)
-    MessageListResponse getOlderMessage(Integer channelPk, LocalDateTime lastMessageTime, String jwtToken);
+    MessagesOnlyResponse getOlderMessage(Integer channelPk, LocalDateTime lastMessageTime, String jwtToken);
 
     // 채널: 기준 messagePk 주변 메시지 조회 (이전 20 + 기준 + 이후 20, 최대 41개)
     MessageListResponse getAroundMessage(Integer channelPk, Long messagePk, String jwtToken);
@@ -45,7 +46,7 @@ public interface ChatService {
     MessageListResponse getLatestDmMessage(Integer dmRoomPk, String jwtToken);
 
     // DM 방별 이전 메시지 조회 (스크롤 시)
-    MessageListResponse getOlderDmMessage(Integer dmRoomPk, LocalDateTime lastMessageTime, String jwtToken);
+    MessagesOnlyResponse getOlderDmMessage(Integer dmRoomPk, LocalDateTime lastMessageTime, String jwtToken);
 
     // DM : 기준 messagePk 주변 메시지 조회 (이전 20 + 기준 + 이후 20, 최대 41개)
     MessageListResponse getAroundDmMessage(Integer dmRoomPk, Long messagePk, String jwtToken);

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
@@ -7,6 +7,7 @@ import com.luminous.aurora.channel.repository.ChannelRepository;
 import com.luminous.aurora.chat.dto.MessageListResponse;
 import com.luminous.aurora.chat.dto.MessageRequest;
 import com.luminous.aurora.chat.dto.MessageResponse;
+import com.luminous.aurora.chat.dto.MessagesOnlyResponse;
 import com.luminous.aurora.chat.entity.Message;
 import com.luminous.aurora.chat.repository.MessageRepository;
 import com.luminous.aurora.common.error.exception.BadRequestException;
@@ -24,7 +25,6 @@ import com.luminous.aurora.member.repository.DmMemberRepository;
 import com.luminous.aurora.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -208,7 +208,7 @@ public class ChatServiceImpl implements ChatService {
      * 사용 시점: 사용자가 채팅창을 위로 스크롤할 때 (무한 스크롤)
      */
     @Override
-    public MessageListResponse getOlderMessage(Integer channelPk, LocalDateTime lastMessageTime, String jwtToken) {
+    public MessagesOnlyResponse getOlderMessage(Integer channelPk, LocalDateTime lastMessageTime, String jwtToken) {
         try {
             Integer userPk = getUserPkFromToken(jwtToken);
             validateChannelAccess(channelPk, userPk);
@@ -218,10 +218,7 @@ public class ChatServiceImpl implements ChatService {
                     .map(this::convertToMessageResponse)
                     .toList();
 
-            Long lastReadMessagePk = getChannelLastReadMessagePk(channelPk, userPk);
-
-            return MessageListResponse.builder()
-                    .lastReadMessagePk(lastReadMessagePk)
+            return MessagesOnlyResponse.builder()
                     .messages(messageResponses)
                     .build();
 
@@ -395,7 +392,7 @@ public class ChatServiceImpl implements ChatService {
      * 사용 시점: 사용자가 DM 채팅창을 위로 스크롤할 때
      */
     @Override
-    public MessageListResponse getOlderDmMessage(Integer dmRoomPk, LocalDateTime lastMessageTime, String jwtToken) {
+    public MessagesOnlyResponse getOlderDmMessage(Integer dmRoomPk, LocalDateTime lastMessageTime, String jwtToken) {
         try {
             Integer userPk = getUserPkFromToken(jwtToken);
             validateDmRoomAccess(dmRoomPk, userPk);
@@ -404,11 +401,8 @@ public class ChatServiceImpl implements ChatService {
             List<MessageResponse> messageResponses = messages.stream()
                     .map(this::convertToMessageResponse)
                     .toList();
-
-            Long lastReadMessagePk = getDmLastReadMessagePk(dmRoomPk, userPk);
-
-            return MessageListResponse.builder()
-                    .lastReadMessagePk(lastReadMessagePk)
+            
+            return MessagesOnlyResponse.builder()
                     .messages(messageResponses)
                     .build();
 

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
@@ -401,7 +401,7 @@ public class ChatServiceImpl implements ChatService {
             List<MessageResponse> messageResponses = messages.stream()
                     .map(this::convertToMessageResponse)
                     .toList();
-            
+
             return MessagesOnlyResponse.builder()
                     .messages(messageResponses)
                     .build();

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
@@ -194,7 +194,7 @@ public class ChatServiceImpl implements ChatService {
      * @param channelPk - 조회할 채널 PK
      * @param lastMessageTime - 현재 화면에서 가장 오래된 메시지의 시간
      * @param jwtToken - 사용자 인증 토큰
-     * @return MessageListResponse - lastReadMessagePk + 메시지 목록
+     * @return MessagesOnlyResponse - 메시지 목록만 (최대 40개, 무한 스크롤에는 lastRead 불필요)
      * <p>
      * 호출되는 곳:
      * - ChatController (REST API) → GET /api/jv/chat/channel/{channelPk}/messages/older
@@ -384,7 +384,7 @@ public class ChatServiceImpl implements ChatService {
      * @param dmRoomPk - 조회할 DM방 PK
      * @param lastMessageTime - 현재 화면에서 가장 오래된 메시지의 시간
      * @param jwtToken - 사용자 인증 토큰
-     * @return List<MessageResponse> - 이전 메시지 목록 (최대 40개)
+     * @return MessagesOnlyResponse - 메시지 목록만 (최대 40개, 무한 스크롤에는 lastRead 불필요)
      * <p>
      * 호출되는 곳:
      * - ChatController (REST API) → GET /api/jv/chat/dm/{dmRoomPk}/messages/older


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> refactor/#209-chat-older-response-messages-only

<br/>

## 🥔 작업 내용

---

- 채널·DM **`GET .../messages/older`** 응답을 `MessageListResponse`에서 **`MessagesOnlyResponse`(`messages`만)** 로 변경했다. 무한 스크롤 시 매 요청마다 내려주던 `lastReadMessagePk`는 해당 요청에서 불필요한 정보라 삭제
- **`ChatService` / `ChatServiceImpl`**: `getOlderMessage`, `getOlderDmMessage` 반환 타입 변경 및 older 경로에서 `lastReadMessagePk` 조회·매핑 제거.
- **`ChatController`**: older 두 엔드포인트의 `ResponseEntity` 제네릭을 `MessagesOnlyResponse`에 맞게 수정.
- 최신·around·newer 등 나머지 메시지 조회 API는 기존과 동일하게 **`MessageListResponse`** 를 유지한다.

<br/>