### PR TITLE
Refactor/#211 use authentication principal for user identification

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/auth/controller/AuthController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/auth/controller/AuthController.java
@@ -5,10 +5,10 @@ import com.luminous.aurora.auth.dto.AuthInfo;
 import com.luminous.aurora.auth.dto.LoginRequest;
 import com.luminous.aurora.auth.dto.SignUpRequest;
 import com.luminous.aurora.auth.dto.TokenResponse;
+import com.luminous.aurora.auth.entity.Users;
 import com.luminous.aurora.auth.service.AuthService;
 import com.luminous.aurora.auth.service.TokenService;
 import com.luminous.aurora.common.error.exception.UnauthorizedException;
-import com.luminous.aurora.jwt.JwtTokenProvider;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,7 +30,6 @@ public class AuthController {
 
     private final AuthService authService;
     private final TokenService tokenService;
-    private final JwtTokenProvider jwtTokenProvider;
 
     @Value("${cookie.secure}")
     private boolean cookieSecure;
@@ -77,16 +77,9 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(@CookieValue(value = "access_token", required = false) String token) {
-        log.info("로그아웃 요청");
+    public ResponseEntity<String> logout(@AuthenticationPrincipal Users user) {
 
-        if (!StringUtils.hasText(token)) {
-            throw new UnauthorizedException("토큰이 없습니다.");
-        }
-
-        // 토큰에서 userEmail 추출
-        String userEmail = jwtTokenProvider.getUserEmailFromToken(token);
-        authService.logout(userEmail);
+        authService.logout(user.getUserEmail());
 
         // 쿠키 삭제
         ResponseCookie accessCookie = ResponseCookie.from("access_token","")
@@ -135,11 +128,10 @@ public class AuthController {
     }
 
     @GetMapping("/info")
-    public ResponseEntity<AuthInfo> getUserInfo(@CookieValue("access_token") String token) {
+    public ResponseEntity<AuthInfo> getUserInfo(@AuthenticationPrincipal Users user) {
         log.info("사용자 정보 조회 요청");
-            String userEmail = jwtTokenProvider.getUserEmailFromToken(token);
-            AuthInfo userInfo = authService.getUserInfo(userEmail);
-            return ResponseEntity.ok(userInfo);
+        AuthInfo userInfo = authService.getUserInfo(user.getUserEmail());
+        return ResponseEntity.ok(userInfo);
 
     }
 

--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatController.java
@@ -1,11 +1,13 @@
 package com.luminous.aurora.chat.controller;
 
+import com.luminous.aurora.auth.entity.Users;
 import com.luminous.aurora.chat.dto.MessageListResponse;
 import com.luminous.aurora.chat.dto.MessagesOnlyResponse;
 import com.luminous.aurora.chat.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -30,8 +32,9 @@ public class ChatController {
      * GET /api/jv/chat/channel/{channelPk}/messages
      */
     @GetMapping("/channel/{channelPk}/messages")
-    public ResponseEntity<MessageListResponse> getLatestChannelMessages(@PathVariable Integer channelPk, @CookieValue("access_token") String jwtToken) {
-        MessageListResponse response = chatService.getLatestMessage(channelPk, jwtToken);
+    public ResponseEntity<MessageListResponse> getLatestChannelMessages(@PathVariable Integer channelPk,
+                                                                        @AuthenticationPrincipal Users user) {
+        MessageListResponse response = chatService.getLatestMessage(channelPk, user.getUserPk());
         log.info("채널 최신 메시지 조회 성공: channelPk={}, messageCount={}", channelPk, response.getMessages().size());
         return ResponseEntity.ok(response);
     }
@@ -41,8 +44,10 @@ public class ChatController {
      * GET /api/jv/chat/channel/{channelPk}/messages/older
      */
     @GetMapping("/channel/{channelPk}/messages/older")
-    public ResponseEntity<MessagesOnlyResponse> getOlderChannelMessages(@PathVariable Integer channelPk, @RequestParam LocalDateTime lastMessageTime, @CookieValue("access_token") String jwtToken) {
-        MessagesOnlyResponse response = chatService.getOlderMessage(channelPk, lastMessageTime, jwtToken);
+    public ResponseEntity<MessagesOnlyResponse> getOlderChannelMessages(@PathVariable Integer channelPk,
+                                                                        @RequestParam LocalDateTime lastMessageTime,
+                                                                        @AuthenticationPrincipal Users user) {
+        MessagesOnlyResponse response = chatService.getOlderMessage(channelPk, lastMessageTime, user.getUserPk());
         log.info("채널 이전 메시지 조회 성공: channelPk={}, messageCount={}, lastMessageTime={}", channelPk, response.getMessages().size(), lastMessageTime);
         return ResponseEntity.ok(response);
     }
@@ -54,8 +59,8 @@ public class ChatController {
     @GetMapping("/channel/{channelPk}/messages/around")
     public ResponseEntity<MessageListResponse> getAroundChannelMessages(@PathVariable Integer channelPk,
                                                                         @RequestParam Long messagePk,
-                                                                        @CookieValue("access_token") String jwtToken) {
-        MessageListResponse response = chatService.getAroundMessage(channelPk, messagePk, jwtToken);
+                                                                        @AuthenticationPrincipal Users user) {
+        MessageListResponse response = chatService.getAroundMessage(channelPk, messagePk, user.getUserPk());
         log.info("채널 around 메시지 조회: channelPk = {}, messagePk = {}, count = {}",
                 channelPk, messagePk, response.getMessages().size());
         return ResponseEntity.ok(response);
@@ -68,8 +73,8 @@ public class ChatController {
     @GetMapping("/channel/{channelPk}/messages/newer")
     public ResponseEntity<MessageListResponse> getNewerChannelMessages(@PathVariable Integer channelPk,
                                                                        @RequestParam Long messagePk,
-                                                                       @CookieValue("access_token") String jwtToken) {
-        MessageListResponse response = chatService.getNewerMessage(channelPk, messagePk, jwtToken);
+                                                                       @AuthenticationPrincipal Users user) {
+        MessageListResponse response = chatService.getNewerMessage(channelPk, messagePk, user.getUserPk());
         log.info("채널 newer 메시지 조회: channelPk = {}, messagePk = {}, count = {}", channelPk, messagePk, response.getMessages().size());
         return ResponseEntity.ok(response);
     }
@@ -79,8 +84,9 @@ public class ChatController {
      * GET /api/jv/chat/dm/{dmRoomPk}/messages
      */
     @GetMapping("/dm/{dmRoomPk}/messages")
-    public ResponseEntity<MessageListResponse> getLatestDmMessages(@PathVariable Integer dmRoomPk, @CookieValue("access_token") String jwtToken) {
-        MessageListResponse response = chatService.getLatestDmMessage(dmRoomPk, jwtToken);
+    public ResponseEntity<MessageListResponse> getLatestDmMessages(@PathVariable Integer dmRoomPk,
+                                                                   @AuthenticationPrincipal Users user) {
+        MessageListResponse response = chatService.getLatestDmMessage(dmRoomPk, user.getUserPk());
         log.info("DM방 최신 메시지 조회 성공: dmRoomPk={}, messageCount={}", dmRoomPk, response.getMessages().size());
         return ResponseEntity.ok(response);
     }
@@ -90,8 +96,10 @@ public class ChatController {
      * GET /api/jv/chat/dm/{dmRoomPk}/messages/older
      */
     @GetMapping("/dm/{dmRoomPk}/messages/older")
-    public ResponseEntity<MessagesOnlyResponse> getOlderDmMessages(@PathVariable Integer dmRoomPk, @RequestParam LocalDateTime lastMessageTime, @CookieValue("access_token") String jwtToken) {
-        MessagesOnlyResponse response = chatService.getOlderDmMessage(dmRoomPk, lastMessageTime, jwtToken);
+    public ResponseEntity<MessagesOnlyResponse> getOlderDmMessages(@PathVariable Integer dmRoomPk,
+                                                                   @RequestParam LocalDateTime lastMessageTime,
+                                                                   @AuthenticationPrincipal Users user) {
+        MessagesOnlyResponse response = chatService.getOlderDmMessage(dmRoomPk, lastMessageTime, user.getUserPk());
         log.info("DM방 이전 메시지 조회 성공: dmRoomPk={}, messageCount={}, lastMessageTime={}", dmRoomPk, response.getMessages().size(), lastMessageTime);
         return ResponseEntity.ok(response);
     }
@@ -103,8 +111,8 @@ public class ChatController {
     @GetMapping("/dm/{dmRoomPk}/messages/around")
     public ResponseEntity<MessageListResponse> getAroundDmMessages(@PathVariable Integer dmRoomPk,
                                                                    @RequestParam Long messagePk,
-                                                                   @CookieValue("access_token") String jwtToken) {
-        MessageListResponse response = chatService.getAroundDmMessage(dmRoomPk, messagePk, jwtToken);
+                                                                   @AuthenticationPrincipal Users user) {
+        MessageListResponse response = chatService.getAroundDmMessage(dmRoomPk, messagePk, user.getUserPk());
         log.info("DM around 메시지 조회 성공: dmRoomPk = {}, messagePk = {}, count = {}", dmRoomPk, messagePk, response.getMessages().size());
         return ResponseEntity.ok(response);
     }
@@ -116,8 +124,8 @@ public class ChatController {
     @GetMapping("/dm/{dmRoomPk}/messages/newer")
     public ResponseEntity<MessageListResponse> getNewerDmMessages(@PathVariable Integer dmRoomPk,
                                                                   @RequestParam Long messagePk,
-                                                                  @CookieValue("access_token") String jwtToken) {
-        MessageListResponse response = chatService.getNewerDmMessage(dmRoomPk, messagePk, jwtToken);
+                                                                  @AuthenticationPrincipal Users user) {
+        MessageListResponse response = chatService.getNewerDmMessage(dmRoomPk, messagePk, user.getUserPk());
         log.info("DM newer 메시지 조회: dmRoomPk = {}, messagePk = {}, count = {}", dmRoomPk, messagePk, response.getMessages().size());
         return ResponseEntity.ok(response);
     }

--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatWebSocketController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatWebSocketController.java
@@ -60,7 +60,8 @@ public class ChatWebSocketController {
 
             }
 
-            Message savedMessage = chatService.saveChannelMessage(messageRequest, channelPk, jwtToken);
+            Integer userPk = extractUserPkFromToken(jwtToken);
+            Message savedMessage = chatService.saveChannelMessage(messageRequest, channelPk, userPk);
 
             // ChatMessage 대신 통합된 MessageResponse 사용
             MessageResponse messageResponse = chatService.convertToMessageResponse(savedMessage);
@@ -114,9 +115,9 @@ public class ChatWebSocketController {
             if (jwtToken == null) {
                 throw new RuntimeException("JWT 토큰을 찾을 수 없습니다.");
             }
-
+            Integer userPk = extractUserPkFromToken(jwtToken);
             // 메시지 저장 및 chatMessage로 변환
-            Message savedMessage = chatService.saveDmMessage(messageRequest, dmRoomPk, jwtToken);
+            Message savedMessage = chatService.saveDmMessage(messageRequest, dmRoomPk, userPk);
 
             // ChatMessage 대신 통합된 MessageResponse 사용
             MessageResponse messageResponse = chatService.convertToMessageResponse(savedMessage);
@@ -161,8 +162,8 @@ public class ChatWebSocketController {
             if (jwtToken == null) {
                 throw new RuntimeException("JWT 토큰을 찾을 수 없습니다.");
             }
-
-            chatService.markChannelAsRead(channelPk, readRequest.getMessagePk(), jwtToken);
+            Integer userPk = extractUserPkFromToken(jwtToken);
+            chatService.markChannelAsRead(channelPk, readRequest.getMessagePk(), userPk);
         } catch (Exception e) {
             log.error("채널 읽음 처리 실패: channelPk={}, {}", channelPk, e.getMessage());
         }
@@ -192,8 +193,8 @@ public class ChatWebSocketController {
             if (jwtToken == null) {
                 throw new RuntimeException("JWT 토큰을 찾을 수 없습니다.");
             }
-
-            chatService.markDmAsRead(dmRoomPk, readRequest.getMessagePk(), jwtToken);
+            Integer userPk = extractUserPkFromToken(jwtToken);
+            chatService.markDmAsRead(dmRoomPk, readRequest.getMessagePk(), userPk);
 
         } catch (Exception e) {
             log.error("DM 읽음 처리 실패: dmRoomPk={}, {}", dmRoomPk, e.getMessage());

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatService.java
@@ -17,51 +17,51 @@ public interface ChatService {
      *
      * @param request 메시지 내용 (content, messageType)
      * @param channelPk 대상 채널 Pk
-     * @param jwtToken 사용자 인증 토큰
+     * @param userPk 메시지를 보낸 사용자 PK
      */
-    Message saveChannelMessage(MessageRequest request,Integer channelPk, String jwtToken);
+    Message saveChannelMessage(MessageRequest request,Integer channelPk, Integer userPk);
 
     /**
      * DM 메시지 저장
      * @param request 메시지 내용 (content, messageType)
      * @param dmRoomPk 대상 DM방 Pk
-     * @param jwtToken 사용자 인증 토큰
+     * @param userPk 메시지를 보낸 사용자 PK
      */
-    Message saveDmMessage(MessageRequest request, Integer dmRoomPk, String jwtToken);
+    Message saveDmMessage(MessageRequest request, Integer dmRoomPk, Integer userPk);
 
 
     // 채널별 최신 메시지 조회 (최초 로드 시)
-    MessageListResponse getLatestMessage(Integer channelPk, String jwtToken);
+    MessageListResponse getLatestMessage(Integer channelPk, Integer userPk);
 
     // 채널별 이전 메시지 조회 (스크롤 시)
-    MessagesOnlyResponse getOlderMessage(Integer channelPk, LocalDateTime lastMessageTime, String jwtToken);
+    MessagesOnlyResponse getOlderMessage(Integer channelPk, LocalDateTime lastMessageTime, Integer userPk);
 
     // 채널: 기준 messagePk 주변 메시지 조회 (이전 20 + 기준 + 이후 20, 최대 41개)
-    MessageListResponse getAroundMessage(Integer channelPk, Long messagePk, String jwtToken);
+    MessageListResponse getAroundMessage(Integer channelPk, Long messagePk, Integer userPk);
 
     // 채널: 기준 messagePk 보다 이후에 온 메시지 40개 오름차순(newer 전용), 기준 메시지 미포함
-    MessageListResponse getNewerMessage(Integer channelPk, Long afterMessagePk, String jwtToken);
+    MessageListResponse getNewerMessage(Integer channelPk, Long afterMessagePk, Integer userPk);
 
     // DM 방별 최신 메시지 조회
-    MessageListResponse getLatestDmMessage(Integer dmRoomPk, String jwtToken);
+    MessageListResponse getLatestDmMessage(Integer dmRoomPk, Integer userPk);
 
     // DM 방별 이전 메시지 조회 (스크롤 시)
-    MessagesOnlyResponse getOlderDmMessage(Integer dmRoomPk, LocalDateTime lastMessageTime, String jwtToken);
+    MessagesOnlyResponse getOlderDmMessage(Integer dmRoomPk, LocalDateTime lastMessageTime, Integer userPk);
 
     // DM : 기준 messagePk 주변 메시지 조회 (이전 20 + 기준 + 이후 20, 최대 41개)
-    MessageListResponse getAroundDmMessage(Integer dmRoomPk, Long messagePk, String jwtToken);
+    MessageListResponse getAroundDmMessage(Integer dmRoomPk, Long messagePk, Integer userPk);
 
     // DM : 기준 messagePk 보다 이후에 온 메시지 40개 오름차순(newer 전용), 기준 메시지 미포함
-    MessageListResponse getNewerDmMessage(Integer dmRoomPk, Long afterMessagePk, String jwtToken);
+    MessageListResponse getNewerDmMessage(Integer dmRoomPk, Long afterMessagePk, Integer userPk);
 
     // 채널 안읽은 메시지 표시용
-    void markChannelAsRead(Integer channelPk, Long messagePk, String jwtToken);
+    void markChannelAsRead(Integer channelPk, Long messagePk, Integer userPk);
 
     // 여러 채널의 안 읽은 메시지 존재 여부 일괄 조회
     List<ChannelUnreadResponse> getChannelsUnreadStatus(List<Integer> channelPks, Integer userPk);
 
     // DM 안읽은 메시지 표시
-    void markDmAsRead(Integer dmRoomPk, Long messagePk, String jwtToken);
+    void markDmAsRead(Integer dmRoomPk, Long messagePk, Integer userPk);
 
     MessageResponse convertToMessageResponse(Message message);
 

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
@@ -17,7 +17,6 @@ import com.luminous.aurora.common.error.exception.NotFoundException;
 import com.luminous.aurora.dmroom.entity.DmRoom;
 import com.luminous.aurora.dmroom.repository.DmRoomRepository;
 import com.luminous.aurora.internal.dto.ChannelUnreadResponse;
-import com.luminous.aurora.jwt.JwtTokenProvider;
 import com.luminous.aurora.member.entity.ChannelMember;
 import com.luminous.aurora.member.entity.DmMember;
 import com.luminous.aurora.member.repository.ChannelMemberRepository;
@@ -41,7 +40,6 @@ public class ChatServiceImpl implements ChatService {
 
     private final MessageRepository messageRepository;
     private final UserRepository userRepository;
-    private final JwtTokenProvider jwtTokenProvider;
     private final MemberService memberService;
     private final ChannelRepository channelRepository;
     private final DmRoomRepository dmRoomRepository;
@@ -53,22 +51,20 @@ public class ChatServiceImpl implements ChatService {
      *
      * @param request - 메시지 내용 (content, messageType)
      * @param channelPk - 대상 채널 PK (WebSocket PathVariable에서 전달)
-     * @param jwtToken - 사용자 인증 토큰
+     * @param userPk 메시지를 보낸 사용자 PK
      * <p>
      * 호출되는 곳:
      * - ChatWebSocketController.sendChannelMessage()
      * <p>
      * 처리 순서:
-     * 1. JWT에서 userPk 추출
-     * 2. 채널 접근 권한 검증
-     * 3. Channel, Users 엔티티 조회
-     * 4. Message 엔티티 생성 및 DB 저장
+     * 1. 채널 접근 권한 검증
+     * 2. Channel, Users 엔티티 조회
+     * 3. Message 엔티티 생성 및 DB 저장
      */
     @Override
     @Transactional
-    public Message saveChannelMessage(MessageRequest request, Integer channelPk, String jwtToken) {
+    public Message saveChannelMessage(MessageRequest request, Integer channelPk, Integer userPk) {
         try {
-            Integer userPk = getUserPkFromToken(jwtToken);
             validateChannelAccess(channelPk, userPk);
 
             Channel channel = channelRepository.findById(channelPk)
@@ -100,22 +96,20 @@ public class ChatServiceImpl implements ChatService {
      *
      * @param request - 메시지 내용 (content, messageType)
      * @param dmRoomPk - 대상 DM방 PK (WebSocket PathVariable에서 전달)
-     * @param jwtToken - 사용자 인증 토큰
+     * @param userPk 메시지를 보낸 사용자 PK
      * <p>
      * 호출되는 곳:
      * - ChatWebSocketController.sendDmMessage()
      * <p>
-     * 처리 순서:
-     * 1. JWT에서 userPk 추출
-     * 2. DM방 접근 권한 검증
-     * 3. DmRoom, Users 엔티티 조회
-     * 4. Message 엔티티 생성 및 DB 저장
+     * 처리 순서
+     * 1. DM방 접근 권한 검증
+     * 2. DmRoom, Users 엔티티 조회
+     * 3. Message 엔티티 생성 및 DB 저장
      */
     @Override
     @Transactional
-    public Message saveDmMessage(MessageRequest request, Integer dmRoomPk, String jwtToken) {
+    public Message saveDmMessage(MessageRequest request, Integer dmRoomPk, Integer userPk) {
         try {
-            Integer userPk = getUserPkFromToken(jwtToken);
             validateDmRoomAccess(dmRoomPk, userPk);
 
             DmRoom dmRoom = dmRoomRepository.findById(dmRoomPk)
@@ -148,24 +142,22 @@ public class ChatServiceImpl implements ChatService {
      * 채널의 최신 메시지 40개 조회 (처음 채널 입장 시)
      *
      * @param channelPk - 조회할 채널 PK
-     * @param jwtToken - 사용자 인증 토큰
+     * @param userPk 조회하는 사용자 PK
      * @return MessageListResponse - lastReadMessagePk + 메시지 목록
      * <p>
      * 호출되는 곳:
      * - ChatController (REST API) → GET /api/jv/chat/channel/{channelPk}/messages
      * <p>
      * 처리 순서:
-     * 1. JWT에서 userPk 추출
-     * 2. 채널 접근 권한 검증
-     * 3. MessageRepository에서 최신 40개 조회
-     * 4. Message → MessageResponse DTO 변환
+     * 1. 채널 접근 권한 검증
+     * 2. MessageRepository에서 최신 40개 조회
+     * 3. Message → MessageResponse DTO 변환
      * <p>
      * 사용 시점: 사용자가 채널에 처음 들어갈 때
      */
     @Override
-    public MessageListResponse getLatestMessage(Integer channelPk, String jwtToken) {
+    public MessageListResponse getLatestMessage(Integer channelPk, Integer userPk) {
         try {
-            Integer userPk = getUserPkFromToken(jwtToken);
             validateChannelAccess(channelPk, userPk);
 
             List<Message> messages = messageRepository.findLatestMessagesByChannelPk(channelPk);
@@ -193,24 +185,22 @@ public class ChatServiceImpl implements ChatService {
      *
      * @param channelPk - 조회할 채널 PK
      * @param lastMessageTime - 현재 화면에서 가장 오래된 메시지의 시간
-     * @param jwtToken - 사용자 인증 토큰
+     * @param userPk 조회하는 사용자 PK
      * @return MessagesOnlyResponse - 메시지 목록만 (최대 40개, 무한 스크롤에는 lastRead 불필요)
      * <p>
      * 호출되는 곳:
      * - ChatController (REST API) → GET /api/jv/chat/channel/{channelPk}/messages/older
      * <p>
      * 처리 순서:
-     * 1. JWT에서 userPk 추출
-     * 2. 채널 접근 권한 검증
-     * 3. lastMessageTime 이전의 메시지 40개 조회
-     * 4. Message → MessageResponse DTO 변환
+     * 1. 채널 접근 권한 검증
+     * 2. lastMessageTime 이전의 메시지 40개 조회
+     * 3. Message → MessageResponse DTO 변환
      * <p>
      * 사용 시점: 사용자가 채팅창을 위로 스크롤할 때 (무한 스크롤)
      */
     @Override
-    public MessagesOnlyResponse getOlderMessage(Integer channelPk, LocalDateTime lastMessageTime, String jwtToken) {
+    public MessagesOnlyResponse getOlderMessage(Integer channelPk, LocalDateTime lastMessageTime, Integer userPk) {
         try {
-            Integer userPk = getUserPkFromToken(jwtToken);
             validateChannelAccess(channelPk, userPk);
 
             List<Message> messages = messageRepository.findOlderMessagesByChannelPk(channelPk, lastMessageTime);
@@ -238,23 +228,21 @@ public class ChatServiceImpl implements ChatService {
      *
      * @param channelPk 조회할 채널 Pk
      * @param messagePk 기준이 되는 메시지 Pk (해당 채널 소속이어야 함)
-     * @param jwtToken 사용자 인증 토큰
+     * @param userPk 조회하는 사용자 PK
      * @return MessageListResponse - LastReadMessagePk + 메시지 목록
      * <p>
      * 호출 되는 곳
      * - ChatController (REST API) -> GET /api/jv/chat/channel/{channelPk}/messages/around
      * <p>
      * 처리 순서
-     * 1. jwt에서 userPk 추출
-     * 2. 채널 접근 권한 검증
-     * 3. 기준 메시지가 해당 채널에 존재하는지 확인
-     * 4. 기준보다 이전/이후 메시지 각각 조회 후 오름차순으로 병합
-     * 5. Message -> MessageResponse 변환
+     * 1. 채널 접근 권한 검증
+     * 2. 기준 메시지가 해당 채널에 존재하는지 확인
+     * 3. 기준보다 이전/이후 메시지 각각 조회 후 오름차순으로 병합
+     * 4. Message -> MessageResponse 변환
      */
     @Override
-    public MessageListResponse getAroundMessage(Integer channelPk, Long messagePk, String jwtToken) {
+    public MessageListResponse getAroundMessage(Integer channelPk, Long messagePk, Integer userPk) {
         try {
-            Integer userPk = getUserPkFromToken(jwtToken);
             validateChannelAccess(channelPk, userPk);
 
             Message anchor = messageRepository.findByMessagePkAndChannelPk_ChannelPk(messagePk, channelPk)
@@ -297,23 +285,21 @@ public class ChatServiceImpl implements ChatService {
      *
      * @param channelPk - 조회할 채널 PK
      * @param afterMessagePk - 커서로 쓰는 메시지 PK (해당 채널에 존재해야 함)
-     * @param jwtToken - 사용자 인증 토큰
+     * @param userPk 조회하는 사용자 PK
      * @return MessageListResponse - lastReadMessagePk + 메시지 목록
      * <p>
      * 호출되는 곳:
      * - ChatController (REST API) → GET /api/jv/chat/channel/{channelPk}/messages/newer
      * <p>
      * 처리 순서:
-     * 1. JWT에서 userPk 추출
-     * 2. 채널 접근 권한 검증
-     * 3. 커서 메시지가 해당 채널에 존재하는지 확인
-     * 4. 이후 메시지 최대 40개 조회
-     * 5. Message → MessageResponse 변환
+     * 1. 채널 접근 권한 검증
+     * 2. 커서 메시지가 해당 채널에 존재하는지 확인
+     * 3. 이후 메시지 최대 40개 조회
+     * 4. Message → MessageResponse 변환
      */
     @Override
-    public MessageListResponse getNewerMessage(Integer channelPk, Long afterMessagePk, String jwtToken) {
+    public MessageListResponse getNewerMessage(Integer channelPk, Long afterMessagePk, Integer userPk) {
         try {
-            Integer userPk = getUserPkFromToken(jwtToken);
             validateChannelAccess(channelPk, userPk);
 
             messageRepository.findByMessagePkAndChannelPk_ChannelPk(afterMessagePk, channelPk)
@@ -343,7 +329,7 @@ public class ChatServiceImpl implements ChatService {
      * DM방의 최신 메시지 40개 조회 (처음 DM방 입장 시)
      *
      * @param dmRoomPk - 조회할 DM방 PK
-     * @param jwtToken - 사용자 인증 토큰
+     * @param userPk 조회하는 사용자 PK
      * @return MessageListResponse - lastReadMessagePk + 메시지 목록
      * <p>
      * 호출되는 곳:
@@ -352,9 +338,8 @@ public class ChatServiceImpl implements ChatService {
      * 사용 시점: 사용자가 DM방에 처음 들어갈 때
      */
     @Override
-    public MessageListResponse getLatestDmMessage(Integer dmRoomPk, String jwtToken) {
+    public MessageListResponse getLatestDmMessage(Integer dmRoomPk, Integer userPk) {
         try {
-            Integer userPk = getUserPkFromToken(jwtToken);
             validateDmRoomAccess(dmRoomPk, userPk);
 
             List<Message> messages = messageRepository.findLatestMessagesByDmRoomPk(dmRoomPk);
@@ -383,7 +368,7 @@ public class ChatServiceImpl implements ChatService {
      *
      * @param dmRoomPk - 조회할 DM방 PK
      * @param lastMessageTime - 현재 화면에서 가장 오래된 메시지의 시간
-     * @param jwtToken - 사용자 인증 토큰
+     * @param userPk 조회하는 사용자 PK
      * @return MessagesOnlyResponse - 메시지 목록만 (최대 40개, 무한 스크롤에는 lastRead 불필요)
      * <p>
      * 호출되는 곳:
@@ -392,9 +377,8 @@ public class ChatServiceImpl implements ChatService {
      * 사용 시점: 사용자가 DM 채팅창을 위로 스크롤할 때
      */
     @Override
-    public MessagesOnlyResponse getOlderDmMessage(Integer dmRoomPk, LocalDateTime lastMessageTime, String jwtToken) {
+    public MessagesOnlyResponse getOlderDmMessage(Integer dmRoomPk, LocalDateTime lastMessageTime, Integer userPk) {
         try {
-            Integer userPk = getUserPkFromToken(jwtToken);
             validateDmRoomAccess(dmRoomPk, userPk);
 
             List<Message> messages = messageRepository.findOlderMessagesByDmRoomPk(dmRoomPk, lastMessageTime);
@@ -422,23 +406,21 @@ public class ChatServiceImpl implements ChatService {
      *
      * @param dmRoomPk - 조회할 DM방 PK
      * @param messagePk - 기준이 되는 메시지 PK (해당 DM방 소속이어야 함)
-     * @param jwtToken - 사용자 인증 토큰
+     * @param userPk 조회하는 사용자 PK
      * @return MessageListResponse - lastReadMessagePk + 메시지 목록
      * <p>
      * 호출되는 곳:
      * - ChatController (REST API) → GET /api/jv/chat/dm/{dmRoomPk}/messages/around
      * <p>
      * 처리 순서:
-     * 1. JWT에서 userPk 추출
-     * 2. DM방 접근 권한 검증
-     * 3. 기준 메시지가 해당 DM방에 존재하는지 확인
-     * 4. 기준보다 이전/이후 메시지 각각 조회 후 오름차순으로 병합
-     * 5. Message → MessageResponse 변환
+     * 1. DM방 접근 권한 검증
+     * 2. 기준 메시지가 해당 DM방에 존재하는지 확인
+     * 3. 기준보다 이전/이후 메시지 각각 조회 후 오름차순으로 병합
+     * 4. Message → MessageResponse 변환
      */
     @Override
-    public MessageListResponse getAroundDmMessage(Integer dmRoomPk, Long messagePk, String jwtToken) {
+    public MessageListResponse getAroundDmMessage(Integer dmRoomPk, Long messagePk, Integer userPk) {
         try {
-            Integer userPk = getUserPkFromToken(jwtToken);
             validateDmRoomAccess(dmRoomPk, userPk);
 
             Message anchor = messageRepository.findByMessagePkAndDmRoomPk_DmRoomPk(messagePk, dmRoomPk)
@@ -480,23 +462,21 @@ public class ChatServiceImpl implements ChatService {
      *
      * @param dmRoomPk - 조회할 DM방 PK
      * @param afterMessagePk - 커서로 쓰는 메시지 PK (해당 DM방에 존재해야 함)
-     * @param jwtToken - 사용자 인증 토큰
+     * @param userPk 조회하는 사용자 PK
      * @return MessageListResponse - lastReadMessagePk + 메시지 목록
      * <p>
      * 호출되는 곳:
      * - ChatController (REST API) → GET /api/jv/chat/dm/{dmRoomPk}/messages/newer
      * <p>
      * 처리 순서:
-     * 1. JWT에서 userPk 추출
-     * 2. DM방 접근 권한 검증
-     * 3. 커서 메시지가 해당 DM방에 존재하는지 확인
-     * 4. 이후 메시지 최대 40개 조회
-     * 5. Message → MessageResponse 변환
+     * 1. DM방 접근 권한 검증
+     * 2. 커서 메시지가 해당 DM방에 존재하는지 확인
+     * 3. 이후 메시지 최대 40개 조회
+     * 4. Message → MessageResponse 변환
      */
     @Override
-    public MessageListResponse getNewerDmMessage(Integer dmRoomPk, Long afterMessagePk, String jwtToken) {
+    public MessageListResponse getNewerDmMessage(Integer dmRoomPk, Long afterMessagePk, Integer userPk) {
         try {
-            Integer userPk = getUserPkFromToken(jwtToken);
             validateDmRoomAccess(dmRoomPk, userPk);
 
             messageRepository.findByMessagePkAndDmRoomPk_DmRoomPk(afterMessagePk, dmRoomPk)
@@ -600,17 +580,16 @@ public class ChatServiceImpl implements ChatService {
      *
      * @param channelPk - 읽음 처리할 채널 PK
      * @param messagePk - 마지막으로 읽은 메시지 PK
-     * @param jwtToken - 사용자 인증 토큰
+     * @param userPk 요청 사용자 PK
      * <p>
      * 호출되는 곳:
      * - ChatWebSocketController → /app/chat/channel/{channelPk}/read
      * <p>
      * 처리 순서:
-     * 1. JWT에서 userPk 추출
-     * 2. 채널 접근 권한 검증
-     * 3. ChannelMember 엔티티 조회 (channelPk + userPk)
-     * 4. 해당 messagePk의 Message 엔티티 조회
-     * 5. ChannelMember.lastReadMessage 업데이트 및 저장
+     * 1. 채널 접근 권한 검증
+     * 2. ChannelMember 엔티티 조회 (channelPk + userPk)
+     * 3. 해당 messagePk의 Message 엔티티 조회
+     * 4. ChannelMember.lastReadMessage 업데이트 및 저장
      * <p>
      * 용도: 프론트에서 사용자가 채널 메시지를 읽었을 때,
      * 마지막으로 읽은 메시지 PK를 전송하여 읽음 위치를 기록
@@ -620,9 +599,8 @@ public class ChatServiceImpl implements ChatService {
      */
     @Override
     @Transactional
-    public void markChannelAsRead(Integer channelPk, Long messagePk, String jwtToken) {
+    public void markChannelAsRead(Integer channelPk, Long messagePk, Integer userPk) {
         try {
-            Integer userPk = getUserPkFromToken(jwtToken);
             validateChannelAccess(channelPk, userPk);
 
             ChannelMember channelMember = channelMemberRepository.findByChannel_ChannelPkAndUser_UserPk(channelPk, userPk)
@@ -648,17 +626,16 @@ public class ChatServiceImpl implements ChatService {
      *
      * @param dmRoomPk - 읽음 처리할 DM방 PK
      * @param messagePk - 마지막으로 읽은 메시지 PK
-     * @param jwtToken - 사용자 인증 토큰
+     * @param userPk 요청 사용자 PK
      * <p>
      * 호출되는 곳:
      * - ChatWebSocketController → /app/chat/dm/{dmRoomPk}/read
      * <p>
      * 처리 순서:
-     * 1. JWT에서 userPk 추출
-     * 2. DM방 접근 권한 검증
-     * 3. DmMember 엔티티 조회 (dmRoomPk + userPk)
-     * 4. 해당 messagePk의 Message 엔티티 조회
-     * 5. DmMember.lastReadMessage 업데이트 및 저장
+     * 1. DM방 접근 권한 검증
+     * 2. DmMember 엔티티 조회 (dmRoomPk + userPk)
+     * 3. 해당 messagePk의 Message 엔티티 조회
+     * 4. DmMember.lastReadMessage 업데이트 및 저장
      * <p>
      * 용도: 프론트에서 사용자가 DM 메시지를 읽었을 때,
      * 마지막으로 읽은 메시지 PK를 전송하여 읽음 위치를 기록
@@ -669,9 +646,8 @@ public class ChatServiceImpl implements ChatService {
      */
     @Override
     @Transactional
-    public void markDmAsRead(Integer dmRoomPk, Long messagePk, String jwtToken) {
+    public void markDmAsRead(Integer dmRoomPk, Long messagePk, Integer userPk) {
         try {
-            Integer userPk = getUserPkFromToken(jwtToken);
             validateDmRoomAccess(dmRoomPk, userPk);
 
             DmMember dmMember = dmMemberRepository.findByDmRoom_DmRoomPkAndUser_UserPk(dmRoomPk, userPk)
@@ -735,25 +711,6 @@ public class ChatServiceImpl implements ChatService {
         }
     }
 
-    /**
-     이 아래는 Private 유틸 함수
-     */
-
-    /**
-     * JWT 토큰에서 userPk 추출
-     *
-     * @param jwtToken - JWT 토큰 문자열
-     * @return Integer - 사용자 PK
-     * <p>
-     * 처리 순서:
-     * 1. JwtTokenProvider로 토큰에서 userEmail 추출
-     * 2. UserRepository에서 userEmail로 userPk 조회
-     */
-    private Integer getUserPkFromToken(String jwtToken) {
-        String userEmail = jwtTokenProvider.getUserEmailFromToken(jwtToken);
-        return userRepository.findUserPkByUserEmail(userEmail)
-                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
-    }
 
     /**
      * 채널에서 현재 사용자의 lastReadMessagePk 조회

--- a/spbackend/src/main/java/com/luminous/aurora/dmroom/controller/DmRoomController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/dmroom/controller/DmRoomController.java
@@ -1,15 +1,14 @@
 package com.luminous.aurora.dmroom.controller;
 
-import com.luminous.aurora.common.error.exception.UnauthorizedException;
+import com.luminous.aurora.auth.entity.Users;
 import com.luminous.aurora.dmroom.dto.DmRoomCreateRequest;
 import com.luminous.aurora.dmroom.dto.DmRoomCreateResponse;
 import com.luminous.aurora.dmroom.service.DmRoomService;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -29,10 +28,9 @@ public class DmRoomController {
     @PostMapping("/rooms")
     public ResponseEntity<DmRoomCreateResponse> createDmRoom(
             @RequestBody DmRoomCreateRequest request,
-            HttpServletRequest httpRequest) {
-        String token = extractTokenFromCookie(httpRequest);
+            @AuthenticationPrincipal Users user) {
         DmRoomCreateResponse response = dmRoomService.createDmRoom(
-                request.getTargetUserEmail(), token);
+                request.getTargetUserEmail(), user.getUserPk());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
@@ -45,29 +43,10 @@ public class DmRoomController {
     @GetMapping("/rooms/by-user")
     public ResponseEntity<DmRoomCreateResponse> getDmRoomByUser(
             @RequestParam String targetUserEmail,
-            HttpServletRequest httpRequest) {
-        String token = extractTokenFromCookie(httpRequest);
+            @AuthenticationPrincipal Users user) {
         DmRoomCreateResponse response = dmRoomService.getDmRoomByUser(
-                targetUserEmail, token);
+                targetUserEmail, user.getUserPk());
 
         return ResponseEntity.ok(response);
-    }
-
-    /**
-     * 쿠키에서 access_token 추출
-     * - 토큰 없으면 UnauthorizedException → 401
-     *
-     * TODO : 지금 이거 컨트롤러별로 쓰고 있는데 공용 유틸로 빼기
-     */
-    private String extractTokenFromCookie(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if ("access_token".equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        throw new UnauthorizedException("JWT 토큰을 찾을 수 없습니다.");
     }
 }

--- a/spbackend/src/main/java/com/luminous/aurora/dmroom/service/DmRoomService.java
+++ b/spbackend/src/main/java/com/luminous/aurora/dmroom/service/DmRoomService.java
@@ -4,9 +4,9 @@ import com.luminous.aurora.dmroom.dto.DmRoomCreateResponse;
 
 public interface DmRoomService {
     // DM 방 생성
-    DmRoomCreateResponse createDmRoom(String targetUserEmail, String jwtToken);
+    DmRoomCreateResponse createDmRoom(String targetUserEmail, Integer userPk);
 
     // 특정 상대방과의 DM 방 조회
     // 생성때와 같은 양식으로 주기때문에 CreateResponse 재활용
-    DmRoomCreateResponse getDmRoomByUser(String targetUserEmail, String jwtToken);
+    DmRoomCreateResponse getDmRoomByUser(String targetUserEmail, Integer userPk);
 }

--- a/spbackend/src/main/java/com/luminous/aurora/dmroom/service/DmRoomServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/dmroom/service/DmRoomServiceImpl.java
@@ -8,7 +8,6 @@ import com.luminous.aurora.common.error.exception.NotFoundException;
 import com.luminous.aurora.dmroom.dto.DmRoomCreateResponse;
 import com.luminous.aurora.dmroom.entity.DmRoom;
 import com.luminous.aurora.dmroom.repository.DmRoomRepository;
-import com.luminous.aurora.jwt.JwtTokenProvider;
 import com.luminous.aurora.member.entity.DmMember;
 import com.luminous.aurora.member.repository.DmMemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +25,6 @@ public class DmRoomServiceImpl implements DmRoomService {
     private final DmRoomRepository dmRoomRepository;
     private final DmMemberRepository dmMemberRepository;
     private final UserRepository userRepository;
-    private final JwtTokenProvider jwtTokenProvider;
 
     /**
      * DM방 생성
@@ -35,7 +33,7 @@ public class DmRoomServiceImpl implements DmRoomService {
      * - dmRoomController -> POST /api/jv/dm/rooms
      * <p>
      * 처리 순서:
-     * 1. JWT에서 요청자 이메일 추출 -> User 조회
+     * 1. userPk로 요청자 User 조회
      * 2. 자기 자신에게 DM 시도 시 -> 400 BadRequest
      * 3. targetUserEmail로 상대방 User 조회 -> 없으면 404
      * 4. 두 유저가 이미 같은 DM방에 있는지 확인 -> 있으면 409
@@ -44,11 +42,12 @@ public class DmRoomServiceImpl implements DmRoomService {
      */
     @Override
     @Transactional
-    public DmRoomCreateResponse createDmRoom(String targetUserEmail, String jwtToken) {
+    public DmRoomCreateResponse createDmRoom(String targetUserEmail, Integer userPk) {
         // 1. 요청자 조회
-        String myEmail = jwtTokenProvider.getUserEmailFromToken(jwtToken);
-        Users myUser = userRepository.findByUserEmail(myEmail)
+        Users myUser = userRepository.findById(userPk)
                 .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+
+        String myEmail = myUser.getUserEmail();
 
         // 2. 자기 자신에게 DM 불가
         if (myEmail.equals(targetUserEmail)) {
@@ -99,17 +98,16 @@ public class DmRoomServiceImpl implements DmRoomService {
      * - DmRoomController → GET /api/jv/dm/rooms/by-user
      *
      * 처리 순서:
-     * 1. JWT 에서 요청자 이메일 추출 -> Users 조회
+     * 1. userPk로 요청자 User 조회
      * 2. targetUserEmail로 상대방 Users 조회 -> 없으면 404
      * 3. 두 유저가 같은 DM 방에 있는지 확인 -> 없으면 404
      * 4. DmRoomCreate 반환
      *
      */
     @Override
-    public DmRoomCreateResponse getDmRoomByUser(String targetUserEmail, String jwtToken) {
-        String myEmail = jwtTokenProvider.getUserEmailFromToken(jwtToken);
+    public DmRoomCreateResponse getDmRoomByUser(String targetUserEmail, Integer userPk) {
 
-        Users myUser = userRepository.findByUserEmail(myEmail)
+        Users myUser = userRepository.findById(userPk)
                 .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
 
         Users targetUser = userRepository.findByUserEmail(targetUserEmail)

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
@@ -1,20 +1,17 @@
 package com.luminous.aurora.userstate.controller;
 
-import com.luminous.aurora.auth.repository.UserRepository;
-import com.luminous.aurora.common.error.exception.*;
+import com.luminous.aurora.auth.entity.Users;
 import com.luminous.aurora.common.error.exception.ForbiddenException;
-import com.luminous.aurora.jwt.JwtTokenProvider;
 import com.luminous.aurora.member.dto.ChannelMemberResponse;
 import com.luminous.aurora.member.dto.DmRoomResponse;
 import com.luminous.aurora.member.service.MemberService;
 import com.luminous.aurora.userstate.dto.*;
 import com.luminous.aurora.userstate.entity.UserStatus;
 import com.luminous.aurora.userstate.service.UserStateService;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -27,18 +24,15 @@ import java.util.List;
 public class UserStateController {
 
     private final UserStateService userStateService;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final UserRepository userRepository;
     private final MemberService memberService;
 
     //사용자 상태 조회
     @GetMapping("/status")
     public ResponseEntity<UserStatusResponse> getCurrentUserStatus(
-            HttpServletRequest request) {
-        Integer userPk = extractUserPkFromRequest(request);
-        UserStatus status = userStateService.getUserStatus(userPk);
+            @AuthenticationPrincipal Users user) {
+        UserStatus status = userStateService.getUserStatus(user.getUserPk());
         UserStatusResponse response = UserStatusResponse.builder()
-                .userPk(userPk)
+                .userPk(user.getUserPk())
                 .status(status)
                 .lastSeen(LocalDateTime.now()) // 실제로는 DB에서 조회
                 .build();
@@ -51,16 +45,11 @@ public class UserStateController {
     @PostMapping("/status")
     public ResponseEntity<UserStatusChangeResponse> setCurrentUserStatus(
             @RequestBody UserStatusChangeRequestForRest request,
-            HttpServletRequest httpRequest) {
-        String token = extractTokenFromCookie(httpRequest);
-        String userEmail = jwtTokenProvider.getUserEmailFromToken(token);
-        Integer userPk = userRepository.findUserPkByUserEmail(userEmail)
-                .orElseThrow(() -> new UnauthorizedException("사용자를 찾을 수 없습니다"));
-
-        userStateService.setUserStatus(userPk, request.getStatus());
+            @AuthenticationPrincipal Users user) {
+        userStateService.setUserStatus(user.getUserPk(), request.getStatus());
 
         UserStatusChangeResponse response = UserStatusChangeResponse.builder()
-                .userEmail(userEmail)
+                .userEmail(user.getUserEmail())
                 .status(request.getStatus())
                 .timestamp(System.currentTimeMillis())
                 .build();
@@ -78,13 +67,11 @@ public class UserStateController {
     @GetMapping("/channel/{channelPk}/members")
     public ResponseEntity<List<ChannelMemberResponse>> getChannelMembers(
             @PathVariable Integer channelPk,
-            HttpServletRequest request) {
+            @AuthenticationPrincipal Users user) {
         try {
-            // JWT에서 현재 사용자 PK 추출
-            Integer userPk = extractUserPkFromRequest(request);
 
             // 채널 멤버가 아니면 403
-            if (!memberService.hasChannelAccess(channelPk, userPk)) {
+            if (!memberService.hasChannelAccess(channelPk, user.getUserPk())) {
                 throw new ForbiddenException("해당 채널에 접근할 권한이 없습니다.");
             }
             List<ChannelMemberResponse> members = userStateService.getChannelMemberWithStatus(channelPk);
@@ -103,38 +90,8 @@ public class UserStateController {
     // DM 멤버 조회 (최신순)
 
     @GetMapping("/dm/rooms")
-    public ResponseEntity<List<DmRoomResponse>> getMyDmRooms(HttpServletRequest request) {
-        Integer userPk = extractUserPkFromRequest(request);
-        List<DmRoomResponse> dmRooms = userStateService.getDmRoomsWithStatus(userPk);
+    public ResponseEntity<List<DmRoomResponse>> getMyDmRooms(@AuthenticationPrincipal Users user) {
+        List<DmRoomResponse> dmRooms = userStateService.getDmRoomsWithStatus(user.getUserPk());
         return ResponseEntity.ok(dmRooms);
-    }
-
-
-    /**
-     * JWT에서 userPk 추출
-     * - 토큰/사용자 없으면 UnauthorizedException → 401
-     */
-    private Integer extractUserPkFromRequest(HttpServletRequest request) {
-        // JWT 토큰 추출 및 userPk 반환
-        String token = extractTokenFromCookie(request);
-        String userEmail = jwtTokenProvider.getUserEmailFromToken(token);
-        return userRepository.findUserPkByUserEmail(userEmail)
-                .orElseThrow(() -> new UnauthorizedException("사용자를 찾을 수 없습니다."));
-    }
-
-    /**
-     * 쿠키에서 access_token 추출
-     * - 토큰 없으면 UnauthorizedException → GlobalExceptionHandler가 401 반환
-     */
-    private String extractTokenFromCookie(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if ("access_token".equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        throw new UnauthorizedException("JWT 토큰을 찾을 수 없습니다.");
     }
 }


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> refactor/-use-authentication-principal-for-user-identification

<br/>

## 🥔 작업 내용

---

- **컨트롤러 사용자 식별 방식 변경**
  - REST 컨트롤러에서 `@CookieValue("access_token")` / `HttpServletRequest` 직접 추출 → `@AuthenticationPrincipal Users user`
  - `JwtAuthenticationFilter`가 이미 SecurityContext에 `Users` 엔티티를 박아두므로 컨트롤러는 principal로 바로 사용
  - 적용: `AuthController(/logout, /info)`, `ChatController`, `DmRoomController`, `UserStateController`
  - 제외: `AuthController(/refresh)` — `refresh_token` 쿠키 그대로 유지 (access 만료 후 호출)

- **Service 시그니처 통일 (`String jwtToken` → `Integer userPk`)**
  - `ChatService` / `ChatServiceImpl`: 12개 메서드
  - `DmRoomService` / `DmRoomServiceImpl`: 2개 메서드
  - `UserStateService`: 변경 없음 (이미 `userPk` 기반)

- **ServiceImpl 내부 정리**
  - `ChatServiceImpl`: `getUserPkFromToken` private 메서드 / `JwtTokenProvider` 의존성 제거
  - `DmRoomServiceImpl`: `JwtTokenProvider` 의존성 제거, `findById(userPk)` 기반으로 변경

- **WebSocket 호출부 정리 (`ChatWebSocketController`)**
  - `chatService.xxx(..., jwtToken)` → `chatService.xxx(..., userPk)`
  - 4곳 (`sendChannelMessage`, `sendDmMessage`, `markChannelAsRead`, `markDmAsRead`)
  - WebSocket 인증 로직(`extractJwtFromSession`, `extractUserPkFromToken`) 자체는 유지 → 백로그 #10에서 별도 PR 예정

- **컨트롤러 헬퍼 + 의존성 정리**
  - `DmRoomController`: `extractTokenFromCookie` 메서드 제거
  - `UserStateController`: `extractUserPkFromRequest` / `extractTokenFromCookie` 메서드 제거, `JwtTokenProvider` / `UserRepository` 필드 제거
  - `AuthController`: `JwtTokenProvider` 필드 제거

### 변경 효과

- 요청당 `userEmail → userPk` 추가 SELECT 1회 제거
- 컨트롤러/서비스가 토큰 문자열을 직접 다루지 않음 → 후속 작업(access 헤더화 등) 시 수정 포인트 최소화
- Service 시그니처가 도메인 식별자(`userPk`)로 단순화 → 단위테스트 용이

### 변경 제외 (별도 이슈/PR)

- `try-catch` 패턴 정리 — `GlobalExceptionHandler` 위임 (별도 PR)
- WebSocket 인증 로직 분리 — `ChannelInterceptor` 또는 `StompAuthSupport` 
- access 토큰 쿠키 → 헤더 + 5분 만료 + refresh 쿠키 분리 (Step A)

<br/>

## 📸 스크린샷 or 영상

(선택사항)

## 💥 확인해주세요!

---

- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.
- [ ] WebSocket 메시지 송수신·읽음 처리 정상 동작 확인 (`ChatWebSocketController` 호출부 변경 영향)
- [ ] `/api/jv/refresh`는 access 만료 후 호출되어도 정상 동작하는지 확인 (`@CookieValue` 유지)

<br/>