### PR TITLE
refactor(#214): 서비스 레이어 try-catch 정리 및 GlobalExceptionHandler 통합

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/auth/service/AuthServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/auth/service/AuthServiceImpl.java
@@ -9,7 +9,6 @@ import com.luminous.aurora.auth.entity.Users;
 import com.luminous.aurora.auth.repository.UserRepository;
 import com.luminous.aurora.common.error.exception.BadRequestException;
 import com.luminous.aurora.common.error.exception.ConflictException;
-import com.luminous.aurora.common.error.exception.InternalServerErrorException;
 import com.luminous.aurora.common.error.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,94 +27,63 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public TokenResponse login(LoginRequest request) {
+        // userEmail로 사용자 조회
+        Users users = userRepository.findByUserEmail(request.getUserEmail())
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 입니다."));
 
-        try {
-            // userEmail로 사용자 조회
-            Users users = userRepository.findByUserEmail(request.getUserEmail())
-                    .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 입니다."));
-
-            // 비밀번호 검증
-            if (!passwordEncoder.matches(request.getPassword(), users.getPassword())) {
-                throw new BadRequestException("비밀번호가 일치하지 않습니다.");
-            }
-
-            // userEmail로 토큰 생성
-            TokenResponse tokens = tokenService.generateTokens(users.getUserEmail());
-
-            log.info("로그인 성공: userEmail ={}", users.getUserEmail());
-
-            return tokens;
-        } catch (NotFoundException | BadRequestException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("로그인 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("로그인 처리 중 서버 오류가 발생했습니다. : " + e.getMessage());
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(request.getPassword(), users.getPassword())) {
+            throw new BadRequestException("비밀번호가 일치하지 않습니다.");
         }
 
+        // userEmail로 토큰 생성
+        TokenResponse tokens = tokenService.generateTokens(users.getUserEmail());
+        log.info("로그인 성공: userEmail ={}", users.getUserEmail());
+        return tokens;
     }
 
     @Override
     @Transactional
     public void signUp(SignUpRequest request) {
-        try {
-            // 중복체크
-            if (userRepository.existsByUserEmail(request.getUserEmail())) {
-                throw new ConflictException("이미 존재하는 이메일 입니다.");
-            }
-
-            // 비밀번호 암호화
-            String encodedPassword = passwordEncoder.encode(request.getPassword());
-
-            // 사용자 생성
-
-            Users users = Users.builder()
-                    .userEmail(request.getUserEmail())
-                    .userName(request.getUserName())
-                    .password(encodedPassword)
-                    .isDeleted(false)
-                    .build();
-
-            userRepository.save(users);
-
-            log.info("회원가입 성공: userEmail = {}", users.getUserEmail());
-        } catch (NotFoundException | BadRequestException | ConflictException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("회원 가입 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("회원가입 처리 중 서버 오류가 발생했습니다 : " + e.getMessage());
+        // 중복체크
+        if (userRepository.existsByUserEmail(request.getUserEmail())) {
+            throw new ConflictException("이미 존재하는 이메일 입니다.");
         }
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        // 사용자 생성
+
+        Users users = Users.builder()
+                .userEmail(request.getUserEmail())
+                .userName(request.getUserName())
+                .password(encodedPassword)
+                .isDeleted(false)
+                .build();
+
+        userRepository.save(users);
+
+        log.info("회원가입 성공: userEmail = {}", users.getUserEmail());
+
     }
 
     @Override
     public void logout(String userEmail) {
-        try {
-            tokenService.logout(userEmail);
-            log.info("로그아웃 완료: userEmail ={}", userEmail);
-        } catch (NotFoundException | BadRequestException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("로그아웃 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("로그아웃 처리 중 서버 오류가 발생했습니다. : " + e.getMessage());
-        }
+        tokenService.logout(userEmail);
+        log.info("로그아웃 완료: userEmail ={}", userEmail);
     }
 
     @Override
     public AuthInfo getUserInfo(String userEmail) {
-        try {
-            Users user = userRepository.findByUserEmail(userEmail)
-                    .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+        Users user = userRepository.findByUserEmail(userEmail)
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
 
-            return AuthInfo.builder()
-                    .userName(user.getUserName())
-                    .userEmail(user.getUserEmail())
-                    .profileImagePath(user.getProfileImagePath())
-                    .build();
-        } catch (NotFoundException | BadRequestException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("사용자 정보 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("사용자를 찾는 시도 중 서버 오류가 발생했습니다 : " + e.getMessage());
-        }
+        return AuthInfo.builder()
+                .userName(user.getUserName())
+                .userEmail(user.getUserEmail())
+                .profileImagePath(user.getProfileImagePath())
+                .build();
 
     }
 }

--- a/spbackend/src/main/java/com/luminous/aurora/auth/service/TokenServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/auth/service/TokenServiceImpl.java
@@ -1,7 +1,6 @@
 package com.luminous.aurora.auth.service;
 
 
-import com.luminous.aurora.common.error.exception.InternalServerErrorException;
 import com.luminous.aurora.common.error.exception.UnauthorizedException;
 import com.luminous.aurora.jwt.JwtTokenProvider;
 import com.luminous.aurora.auth.dto.TokenResponse;
@@ -27,27 +26,22 @@ public class TokenServiceImpl implements TokenService {
 
     @Override
     public TokenResponse generateTokens(String userEmail) {
-        try {
-            // Access Token 생성
-            String accessToken = jwtTokenProvider.generateAccessToken(userEmail);
+        // Access Token 생성
+        String accessToken = jwtTokenProvider.generateAccessToken(userEmail);
 
-            // refreshToken 생성
-            String refreshToken = jwtTokenProvider.generateRefreshToken(userEmail);
+        // refreshToken 생성
+        String refreshToken = jwtTokenProvider.generateRefreshToken(userEmail);
 
-            // Redis에 토큰 저장
-            tokenRedisRepository.saveToken(userEmail, accessToken, accessTokenValidity);
-            tokenRedisRepository.saveToken(userEmail + ":refresh", refreshToken, refreshTokenValidity);
+        // Redis에 토큰 저장
+        tokenRedisRepository.saveToken(userEmail, accessToken, accessTokenValidity);
+        tokenRedisRepository.saveToken(userEmail + ":refresh", refreshToken, refreshTokenValidity);
 
-            log.info("토큰 생성 완료: userEmail = {}", userEmail);
+        log.info("토큰 생성 완료: userEmail = {}", userEmail);
 
-            return TokenResponse.builder()
-                    .accessToken(accessToken)
-                    .refreshToken(refreshToken)
-                    .build();
-        } catch (Exception e) {
-            log.error("토큰 생성 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("토큰 생성 중 서버 오류가 발생했습니다. : " + e.getMessage());
-        }
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
     }
 
     @Override
@@ -68,33 +62,20 @@ public class TokenServiceImpl implements TokenService {
 
     @Override
     public void logout(String userEmail) {
-        try {
-            tokenRedisRepository.deleteToken(userEmail);
-            tokenRedisRepository.deleteToken(userEmail + ":refresh");
-            log.info("로그아웃 완료 : userEmail = {}", userEmail);
-        } catch (Exception e) {
-            log.error("로그아웃 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("로그아웃 처리 중 서버 오류가 발생했습니다 : " + e.getMessage());
-        }
+        tokenRedisRepository.deleteToken(userEmail);
+        tokenRedisRepository.deleteToken(userEmail + ":refresh");
+        log.info("로그아웃 완료 : userEmail = {}", userEmail);
     }
 
     @Override
     public TokenResponse refreshToken(String refreshToken) {
-        try {
-            String userEmail = jwtTokenProvider.getUserEmailFromToken(refreshToken);
+        String userEmail = jwtTokenProvider.getUserEmailFromToken(refreshToken);
 
-            // refresh token이 redis에 있는지 확인
-            if (!tokenRedisRepository.hasToken(userEmail + ":refresh")) {
-                throw new UnauthorizedException("유효하지 않은 Refresh Token 입니다.");
-            }
-            // 있다면 새로운 토큰 생성
-            return generateTokens(userEmail);
-        } catch (UnauthorizedException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("토큰 갱신 실패: {}", e.getMessage());
-            throw new InternalServerErrorException("토큰 갱신 중 서버 오류가 발생했습니다: " + e.getMessage());
+        // refresh token이 redis에 있는지 확인
+        if (!tokenRedisRepository.hasToken(userEmail + ":refresh")) {
+            throw new UnauthorizedException("유효하지 않은 Refresh Token 입니다.");
         }
+        // 있다면 새로운 토큰 생성
+        return generateTokens(userEmail);
     }
-
 }

--- a/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/service/ChatServiceImpl.java
@@ -10,9 +10,7 @@ import com.luminous.aurora.chat.dto.MessageResponse;
 import com.luminous.aurora.chat.dto.MessagesOnlyResponse;
 import com.luminous.aurora.chat.entity.Message;
 import com.luminous.aurora.chat.repository.MessageRepository;
-import com.luminous.aurora.common.error.exception.BadRequestException;
 import com.luminous.aurora.common.error.exception.ForbiddenException;
-import com.luminous.aurora.common.error.exception.InternalServerErrorException;
 import com.luminous.aurora.common.error.exception.NotFoundException;
 import com.luminous.aurora.dmroom.entity.DmRoom;
 import com.luminous.aurora.dmroom.repository.DmRoomRepository;
@@ -64,31 +62,25 @@ public class ChatServiceImpl implements ChatService {
     @Override
     @Transactional
     public Message saveChannelMessage(MessageRequest request, Integer channelPk, Integer userPk) {
-        try {
-            validateChannelAccess(channelPk, userPk);
+        validateChannelAccess(channelPk, userPk);
 
-            Channel channel = channelRepository.findById(channelPk)
-                    .orElseThrow(() -> new NotFoundException("채널을 찾을 수 없습니다."));
+        Channel channel = channelRepository.findById(channelPk)
+                .orElseThrow(() -> new NotFoundException("채널을 찾을 수 없습니다."));
 
-            Users user = userRepository.findById(userPk)
-                    .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+        Users user = userRepository.findById(userPk)
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
 
-            Message message = Message.builder()
-                    .channelPk(channel)
-                    .userPk(user)
-                    .content(request.getContent())
-                    .messageType(request.getMessageType() != null ? request.getMessageType() : "TEXT")
-                    .build();
+        Message message = Message.builder()
+                .channelPk(channel)
+                .userPk(user)
+                .content(request.getContent())
+                .messageType(request.getMessageType() != null ? request.getMessageType() : "TEXT")
+                .build();
 
-            Message savedMessage = messageRepository.save(message);
+        Message savedMessage = messageRepository.save(message);
 
-            return savedMessage;
-        } catch (ForbiddenException | NotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("메시지 저장 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("메시지 저장 중 서버 오류가 발생했습니다. : " + e.getMessage());
-        }
+        return savedMessage;
+
     }
 
     /**
@@ -109,33 +101,26 @@ public class ChatServiceImpl implements ChatService {
     @Override
     @Transactional
     public Message saveDmMessage(MessageRequest request, Integer dmRoomPk, Integer userPk) {
-        try {
-            validateDmRoomAccess(dmRoomPk, userPk);
+        validateDmRoomAccess(dmRoomPk, userPk);
 
-            DmRoom dmRoom = dmRoomRepository.findById(dmRoomPk)
-                    .orElseThrow(() -> new NotFoundException("DM 방을 찾을 수 없습니다."));
+        DmRoom dmRoom = dmRoomRepository.findById(dmRoomPk)
+                .orElseThrow(() -> new NotFoundException("DM 방을 찾을 수 없습니다."));
 
-            Users user = userRepository
-                    .findById(userPk)
-                    .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+        Users user = userRepository
+                .findById(userPk)
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
 
-            Message message = Message.builder()
-                    .dmRoomPk(dmRoom)
-                    .userPk(user)
-                    .content(request.getContent())
-                    .messageType(request.getMessageType() != null ? request.getMessageType() : "TEXT")
-                    .build();
+        Message message = Message.builder()
+                .dmRoomPk(dmRoom)
+                .userPk(user)
+                .content(request.getContent())
+                .messageType(request.getMessageType() != null ? request.getMessageType() : "TEXT")
+                .build();
 
-            Message savedMessage = messageRepository.save(message);
-            log.info("DM 메시지 저장: dmRoomPk = {}, userPk = {}", dmRoomPk, userPk);
+        Message savedMessage = messageRepository.save(message);
+        log.info("DM 메시지 저장: dmRoomPk = {}, userPk = {}", dmRoomPk, userPk);
 
-            return savedMessage;
-        } catch (ForbiddenException | NotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("DM 메시지 저장 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("메시지 저장 중 서버 오류가 발생했습니다.: " + e.getMessage());
-        }
+        return savedMessage;
     }
 
     /**
@@ -157,27 +142,19 @@ public class ChatServiceImpl implements ChatService {
      */
     @Override
     public MessageListResponse getLatestMessage(Integer channelPk, Integer userPk) {
-        try {
-            validateChannelAccess(channelPk, userPk);
+        validateChannelAccess(channelPk, userPk);
 
-            List<Message> messages = messageRepository.findLatestMessagesByChannelPk(channelPk);
-            List<MessageResponse> messageResponses = messages.stream()
-                    .map(this::convertToMessageResponse)
-                    .toList();
+        List<Message> messages = messageRepository.findLatestMessagesByChannelPk(channelPk);
+        List<MessageResponse> messageResponses = messages.stream()
+                .map(this::convertToMessageResponse)
+                .toList();
 
-            Long lastReadMessagePk = getChannelLastReadMessagePk(channelPk, userPk);
+        Long lastReadMessagePk = getChannelLastReadMessagePk(channelPk, userPk);
 
-            return MessageListResponse.builder()
-                    .lastReadMessagePk(lastReadMessagePk)
-                    .messages(messageResponses)
-                    .build();
-
-        } catch (ForbiddenException | NotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("최신 메시지 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("최신 메시지 조회 중 서버 오류가 발생했습니다. : " + e.getMessage());
-        }
+        return MessageListResponse.builder()
+                .lastReadMessagePk(lastReadMessagePk)
+                .messages(messageResponses)
+                .build();
     }
 
     /**
@@ -200,24 +177,16 @@ public class ChatServiceImpl implements ChatService {
      */
     @Override
     public MessagesOnlyResponse getOlderMessage(Integer channelPk, LocalDateTime lastMessageTime, Integer userPk) {
-        try {
-            validateChannelAccess(channelPk, userPk);
+        validateChannelAccess(channelPk, userPk);
 
-            List<Message> messages = messageRepository.findOlderMessagesByChannelPk(channelPk, lastMessageTime);
-            List<MessageResponse> messageResponses = messages.stream()
-                    .map(this::convertToMessageResponse)
-                    .toList();
+        List<Message> messages = messageRepository.findOlderMessagesByChannelPk(channelPk, lastMessageTime);
+        List<MessageResponse> messageResponses = messages.stream()
+                .map(this::convertToMessageResponse)
+                .toList();
 
-            return MessagesOnlyResponse.builder()
-                    .messages(messageResponses)
-                    .build();
-
-        } catch (ForbiddenException | NotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("이전 메시지 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("이전 메시지 조회 중 서버 오류가 발생했습니다. " + e.getMessage());
-        }
+        return MessagesOnlyResponse.builder()
+                .messages(messageResponses)
+                .build();
     }
 
     /**
@@ -242,39 +211,32 @@ public class ChatServiceImpl implements ChatService {
      */
     @Override
     public MessageListResponse getAroundMessage(Integer channelPk, Long messagePk, Integer userPk) {
-        try {
-            validateChannelAccess(channelPk, userPk);
+        validateChannelAccess(channelPk, userPk);
 
-            Message anchor = messageRepository.findByMessagePkAndChannelPk_ChannelPk(messagePk, channelPk)
-                    .orElseThrow(() -> new NotFoundException("기준메시지가 해당 채널에 없음"));
+        Message anchor = messageRepository.findByMessagePkAndChannelPk_ChannelPk(messagePk, channelPk)
+                .orElseThrow(() -> new NotFoundException("기준메시지가 해당 채널에 없음"));
 
-            List<Message> older = messageRepository.findChannelMessagesStrictlyOlderThan(channelPk, messagePk);
-            java.util.Collections.reverse(older);
+        List<Message> older = messageRepository.findChannelMessagesStrictlyOlderThan(channelPk, messagePk);
+        java.util.Collections.reverse(older);
 
-            List<Message> newer = messageRepository.findChannelMessagesStrictlyNewerThan(channelPk, messagePk);
+        List<Message> newer = messageRepository.findChannelMessagesStrictlyNewerThan(channelPk, messagePk);
 
-            ArrayList<Message> combined = new ArrayList<>(older.size() + 1 + newer.size());
+        ArrayList<Message> combined = new ArrayList<>(older.size() + 1 + newer.size());
 
-            combined.addAll(older);
-            combined.add(anchor);
-            combined.addAll(newer);
+        combined.addAll(older);
+        combined.add(anchor);
+        combined.addAll(newer);
 
-            Long lastReadMessagePk = getChannelLastReadMessagePk(channelPk, userPk);
+        Long lastReadMessagePk = getChannelLastReadMessagePk(channelPk, userPk);
 
-            List<MessageResponse> messageResponse = combined.stream()
-                    .map(this::convertToMessageResponse)
-                    .toList();
+        List<MessageResponse> messageResponse = combined.stream()
+                .map(this::convertToMessageResponse)
+                .toList();
 
-            return MessageListResponse.builder()
-                    .lastReadMessagePk(lastReadMessagePk)
-                    .messages(messageResponse)
-                    .build();
-        } catch (ForbiddenException | NotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("채널 around 메시지 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("채널 around 메시지 조회 중 서버 오류가 발생 했습니다 : " + e.getMessage());
-        }
+        return MessageListResponse.builder()
+                .lastReadMessagePk(lastReadMessagePk)
+                .messages(messageResponse)
+                .build();
     }
 
     /**
@@ -299,29 +261,22 @@ public class ChatServiceImpl implements ChatService {
      */
     @Override
     public MessageListResponse getNewerMessage(Integer channelPk, Long afterMessagePk, Integer userPk) {
-        try {
-            validateChannelAccess(channelPk, userPk);
+        validateChannelAccess(channelPk, userPk);
 
-            messageRepository.findByMessagePkAndChannelPk_ChannelPk(afterMessagePk, channelPk)
-                    .orElseThrow(() -> new NotFoundException("기준 메시지가 해당 채널에 없음"));
+        messageRepository.findByMessagePkAndChannelPk_ChannelPk(afterMessagePk, channelPk)
+                .orElseThrow(() -> new NotFoundException("기준 메시지가 해당 채널에 없음"));
 
-            List<Message> messages = messageRepository.findChannelMessagesNewerThanAfterPk(channelPk, afterMessagePk);
-            List<MessageResponse> messageResponses = messages.stream()
-                    .map(this::convertToMessageResponse)
-                    .toList();
+        List<Message> messages = messageRepository.findChannelMessagesNewerThanAfterPk(channelPk, afterMessagePk);
+        List<MessageResponse> messageResponses = messages.stream()
+                .map(this::convertToMessageResponse)
+                .toList();
 
-            Long lastReadMessagePk = getChannelLastReadMessagePk(channelPk, userPk);
+        Long lastReadMessagePk = getChannelLastReadMessagePk(channelPk, userPk);
 
-            return MessageListResponse.builder()
-                    .lastReadMessagePk(lastReadMessagePk)
-                    .messages(messageResponses)
-                    .build();
-        } catch (ForbiddenException | NotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("채널 newer 메시지 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("채널 newer 메시지 조회 중 서버 오류가 발생했습니다. : " + e.getMessage());
-        }
+        return MessageListResponse.builder()
+                .lastReadMessagePk(lastReadMessagePk)
+                .messages(messageResponses)
+                .build();
     }
 
 
@@ -339,28 +294,20 @@ public class ChatServiceImpl implements ChatService {
      */
     @Override
     public MessageListResponse getLatestDmMessage(Integer dmRoomPk, Integer userPk) {
-        try {
-            validateDmRoomAccess(dmRoomPk, userPk);
+        validateDmRoomAccess(dmRoomPk, userPk);
 
-            List<Message> messages = messageRepository.findLatestMessagesByDmRoomPk(dmRoomPk);
-            List<MessageResponse> messageResponses = messages.stream()
-                    .map(this::convertToMessageResponse)
-                    .toList();
+        List<Message> messages = messageRepository.findLatestMessagesByDmRoomPk(dmRoomPk);
+        List<MessageResponse> messageResponses = messages.stream()
+                .map(this::convertToMessageResponse)
+                .toList();
 
-            Long lastReadMessagePk = getDmLastReadMessagePk(dmRoomPk, userPk);
+        Long lastReadMessagePk = getDmLastReadMessagePk(dmRoomPk, userPk);
 
-            return MessageListResponse
-                    .builder()
-                    .lastReadMessagePk(lastReadMessagePk)
-                    .messages(messageResponses)
-                    .build();
-
-        } catch (ForbiddenException | NotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("최신 DM 메시지 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("최신 DM 메시지 조회 중 서버 오류가 발생했습니다 : " + e.getMessage());
-        }
+        return MessageListResponse
+                .builder()
+                .lastReadMessagePk(lastReadMessagePk)
+                .messages(messageResponses)
+                .build();
     }
 
     /**
@@ -378,24 +325,16 @@ public class ChatServiceImpl implements ChatService {
      */
     @Override
     public MessagesOnlyResponse getOlderDmMessage(Integer dmRoomPk, LocalDateTime lastMessageTime, Integer userPk) {
-        try {
-            validateDmRoomAccess(dmRoomPk, userPk);
+        validateDmRoomAccess(dmRoomPk, userPk);
 
-            List<Message> messages = messageRepository.findOlderMessagesByDmRoomPk(dmRoomPk, lastMessageTime);
-            List<MessageResponse> messageResponses = messages.stream()
-                    .map(this::convertToMessageResponse)
-                    .toList();
+        List<Message> messages = messageRepository.findOlderMessagesByDmRoomPk(dmRoomPk, lastMessageTime);
+        List<MessageResponse> messageResponses = messages.stream()
+                .map(this::convertToMessageResponse)
+                .toList();
 
-            return MessagesOnlyResponse.builder()
-                    .messages(messageResponses)
-                    .build();
-
-        } catch (ForbiddenException | NotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("이전 DM 메시지 조회 실패: {}", e.getMessage());
-            throw new InternalServerErrorException("이전 DM 메시지 조회 중 서버 오류가 발생했습니다: " + e.getMessage());
-        }
+        return MessagesOnlyResponse.builder()
+                .messages(messageResponses)
+                .build();
     }
 
     /**
@@ -420,38 +359,31 @@ public class ChatServiceImpl implements ChatService {
      */
     @Override
     public MessageListResponse getAroundDmMessage(Integer dmRoomPk, Long messagePk, Integer userPk) {
-        try {
-            validateDmRoomAccess(dmRoomPk, userPk);
+        validateDmRoomAccess(dmRoomPk, userPk);
 
-            Message anchor = messageRepository.findByMessagePkAndDmRoomPk_DmRoomPk(messagePk, dmRoomPk)
-                    .orElseThrow(() -> new NotFoundException("기준 메시지가 해당 DM 방에 없습니다."));
+        Message anchor = messageRepository.findByMessagePkAndDmRoomPk_DmRoomPk(messagePk, dmRoomPk)
+                .orElseThrow(() -> new NotFoundException("기준 메시지가 해당 DM 방에 없습니다."));
 
-            List<Message> older = messageRepository.findDmMessagesStrictlyOlderThan(dmRoomPk, messagePk);
-            java.util.Collections.reverse(older);
+        List<Message> older = messageRepository.findDmMessagesStrictlyOlderThan(dmRoomPk, messagePk);
+        java.util.Collections.reverse(older);
 
-            List<Message> newer = messageRepository.findDmMessagesStrictlyNewerThan(dmRoomPk, messagePk);
+        List<Message> newer = messageRepository.findDmMessagesStrictlyNewerThan(dmRoomPk, messagePk);
 
-            ArrayList<Message> combined = new ArrayList<>(older.size() + 1 + newer.size());
-            combined.addAll(older);
-            combined.add(anchor);
-            combined.addAll(newer);
+        ArrayList<Message> combined = new ArrayList<>(older.size() + 1 + newer.size());
+        combined.addAll(older);
+        combined.add(anchor);
+        combined.addAll(newer);
 
-            List<MessageResponse> messageResponses = combined.stream()
-                    .map(this::convertToMessageResponse)
-                    .toList();
+        List<MessageResponse> messageResponses = combined.stream()
+                .map(this::convertToMessageResponse)
+                .toList();
 
-            Long lastReadMessagePk = getDmLastReadMessagePk(dmRoomPk, userPk);
+        Long lastReadMessagePk = getDmLastReadMessagePk(dmRoomPk, userPk);
 
-            return MessageListResponse.builder()
-                    .lastReadMessagePk(lastReadMessagePk)
-                    .messages(messageResponses)
-                    .build();
-        } catch (ForbiddenException | NotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("DM around 메시지 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("DM around 메시지 조회 중 서버 오류가 발생했습니다. : " + e.getMessage());
-        }
+        return MessageListResponse.builder()
+                .lastReadMessagePk(lastReadMessagePk)
+                .messages(messageResponses)
+                .build();
     }
 
     /**
@@ -476,30 +408,22 @@ public class ChatServiceImpl implements ChatService {
      */
     @Override
     public MessageListResponse getNewerDmMessage(Integer dmRoomPk, Long afterMessagePk, Integer userPk) {
-        try {
-            validateDmRoomAccess(dmRoomPk, userPk);
+        validateDmRoomAccess(dmRoomPk, userPk);
 
-            messageRepository.findByMessagePkAndDmRoomPk_DmRoomPk(afterMessagePk, dmRoomPk)
-                    .orElseThrow(() -> new NotFoundException("기준 메시지가 해당 DM 방에 없습니다."));
+        messageRepository.findByMessagePkAndDmRoomPk_DmRoomPk(afterMessagePk, dmRoomPk)
+                .orElseThrow(() -> new NotFoundException("기준 메시지가 해당 DM 방에 없습니다."));
 
-            List<Message> messages = messageRepository.findDmMessagesNewerThanAfterPk(dmRoomPk, afterMessagePk);
-            List<MessageResponse> messageResponses = messages.stream()
-                    .map(this::convertToMessageResponse)
-                    .toList();
+        List<Message> messages = messageRepository.findDmMessagesNewerThanAfterPk(dmRoomPk, afterMessagePk);
+        List<MessageResponse> messageResponses = messages.stream()
+                .map(this::convertToMessageResponse)
+                .toList();
 
-            Long lastReadMessagePk = getDmLastReadMessagePk(dmRoomPk, userPk);
+        Long lastReadMessagePk = getDmLastReadMessagePk(dmRoomPk, userPk);
 
-            return MessageListResponse.builder()
-                    .lastReadMessagePk(lastReadMessagePk)
-                    .messages(messageResponses)
-                    .build();
-
-        } catch (ForbiddenException | NotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("DM newer 메시지 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("DM newer 메시지 조회 중 서버 오류가 발생했습니다. : " + e.getMessage());
-        }
+        return MessageListResponse.builder()
+                .lastReadMessagePk(lastReadMessagePk)
+                .messages(messageResponses)
+                .build();
     }
 
     /**
@@ -530,43 +454,37 @@ public class ChatServiceImpl implements ChatService {
      */
     @Override
     public List<ChannelUnreadResponse> getChannelsUnreadStatus(List<Integer> channelPks, Integer userPk) {
-        try {
-            return channelPks.stream().map(channelPk -> {
-                Optional<ChannelMember> memberOpt = channelMemberRepository.findByChannel_ChannelPkAndUser_UserPk(channelPk, userPk);
+        return channelPks.stream().map(channelPk -> {
+            Optional<ChannelMember> memberOpt = channelMemberRepository.findByChannel_ChannelPkAndUser_UserPk(channelPk, userPk);
 
-                if (memberOpt.isEmpty()) {
-                    // 멤버가 아니면 → unread 없음 (볼 권한 자체가 없으니)
-                    return ChannelUnreadResponse.builder()
-                            .channelPk(channelPk)
-                            .hasUnread(false)
-                            .build();
-                }
-
-                ChannelMember member = memberOpt.get();
-                boolean hasUnread;
-
-                if (member.getLastReadMessage() == null) {
-                    // 한 번도 읽은 적 없음 → 채널에 메시지가 1개라도 있으면 unread
-                    hasUnread = messageRepository.existsByChannelPk_ChannelPk(channelPk);
-                } else {
-                    // 읽은 적 있음 → lastReadMessage 이후에 다른 사람이 보낸 메시지가 있는지 확인
-
-                    hasUnread = messageRepository.existsUnreadMessages(
-                            channelPk,
-                            member.getLastReadMessage().getMessagePk(),
-                            userPk);
-                }
-
+            if (memberOpt.isEmpty()) {
+                // 멤버가 아니면 → unread 없음 (볼 권한 자체가 없으니)
                 return ChannelUnreadResponse.builder()
                         .channelPk(channelPk)
-                        .hasUnread(hasUnread)
+                        .hasUnread(false)
                         .build();
-            }).collect(Collectors.toList());
+            }
 
-        } catch (Exception e) {
-            log.error("채널 일괄 안 읽음 상태 조회 실패: {}", e.getMessage());
-            throw new InternalServerErrorException("채널 안 읽음 상태 조회 중 서버 오류가 발생했습니다: " + e.getMessage());
-        }
+            ChannelMember member = memberOpt.get();
+            boolean hasUnread;
+
+            if (member.getLastReadMessage() == null) {
+                // 한 번도 읽은 적 없음 → 채널에 메시지가 1개라도 있으면 unread
+                hasUnread = messageRepository.existsByChannelPk_ChannelPk(channelPk);
+            } else {
+                // 읽은 적 있음 → lastReadMessage 이후에 다른 사람이 보낸 메시지가 있는지 확인
+
+                hasUnread = messageRepository.existsUnreadMessages(
+                        channelPk,
+                        member.getLastReadMessage().getMessagePk(),
+                        userPk);
+            }
+
+            return ChannelUnreadResponse.builder()
+                    .channelPk(channelPk)
+                    .hasUnread(hasUnread)
+                    .build();
+        }).collect(Collectors.toList());
     }
 
     /**
@@ -600,25 +518,18 @@ public class ChatServiceImpl implements ChatService {
     @Override
     @Transactional
     public void markChannelAsRead(Integer channelPk, Long messagePk, Integer userPk) {
-        try {
-            validateChannelAccess(channelPk, userPk);
+        validateChannelAccess(channelPk, userPk);
 
-            ChannelMember channelMember = channelMemberRepository.findByChannel_ChannelPkAndUser_UserPk(channelPk, userPk)
-                    .orElseThrow(() -> new NotFoundException("채널 멤버를 찾을 수 없습니다."));
+        ChannelMember channelMember = channelMemberRepository.findByChannel_ChannelPkAndUser_UserPk(channelPk, userPk)
+                .orElseThrow(() -> new NotFoundException("채널 멤버를 찾을 수 없습니다."));
 
-            Message message = messageRepository.findById(messagePk)
-                    .orElseThrow(() -> new NotFoundException("메시지를 찾을 수 없습니다."));
+        Message message = messageRepository.findById(messagePk)
+                .orElseThrow(() -> new NotFoundException("메시지를 찾을 수 없습니다."));
 
-            channelMember.setLastReadMessage(message);
-            channelMemberRepository.save(channelMember);
+        channelMember.setLastReadMessage(message);
+        channelMemberRepository.save(channelMember);
 
-            log.info("채널 읽음 처리: channelPk={}, userPk={}, messagePk={}", channelPk, userPk, messagePk);
-        } catch (ForbiddenException | NotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("채널 읽음 처리 실패: {}", e.getMessage());
-            throw new InternalServerErrorException("채널 읽음 처리 중 서버 오류가 발생했습니다: " + e.getMessage());
-        }
+        log.info("채널 읽음 처리: channelPk={}, userPk={}, messagePk={}", channelPk, userPk, messagePk);
     }
 
     /**
@@ -647,24 +558,18 @@ public class ChatServiceImpl implements ChatService {
     @Override
     @Transactional
     public void markDmAsRead(Integer dmRoomPk, Long messagePk, Integer userPk) {
-        try {
-            validateDmRoomAccess(dmRoomPk, userPk);
+        validateDmRoomAccess(dmRoomPk, userPk);
 
-            DmMember dmMember = dmMemberRepository.findByDmRoom_DmRoomPkAndUser_UserPk(dmRoomPk, userPk)
-                    .orElseThrow(() -> new NotFoundException("DM 멤버를 찾을 수 없습니다."));
+        DmMember dmMember = dmMemberRepository.findByDmRoom_DmRoomPkAndUser_UserPk(dmRoomPk, userPk)
+                .orElseThrow(() -> new NotFoundException("DM 멤버를 찾을 수 없습니다."));
 
-            Message message = messageRepository.findById(messagePk)
-                    .orElseThrow(() -> new NotFoundException("메시지를 찾을 수 없습니다."));
+        Message message = messageRepository.findById(messagePk)
+                .orElseThrow(() -> new NotFoundException("메시지를 찾을 수 없습니다."));
 
-            dmMember.setLastReadMessage(message);
-            dmMemberRepository.save(dmMember);
+        dmMember.setLastReadMessage(message);
+        dmMemberRepository.save(dmMember);
 
-            log.info("DM 읽음 처리 : dmRoomPK ={}, userPk={}, messagePk={}", dmRoomPk, userPk, messagePk);
-        } catch (ForbiddenException | NotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new InternalServerErrorException("DM 읽음 처리 중 서버 오류가 발생했습니다: " + e.getMessage());
-        }
+        log.info("DM 읽음 처리 : dmRoomPK ={}, userPk={}, messagePk={}", dmRoomPk, userPk, messagePk);
     }
 
     /**
@@ -690,25 +595,17 @@ public class ChatServiceImpl implements ChatService {
      */
     @Override
     public MessageResponse convertToMessageResponse(Message message) {
-        try {
-            Users user = message.getUserPk();
+        Users user = message.getUserPk();
 
-            return MessageResponse.builder()
-                    .messagePk(message.getMessagePk())
-                    .userEmail(user.getUserEmail())
-                    .userName(user.getUserName())
-                    .userProfileImage(user.getProfileImagePath())
-                    .content(message.getContent())
-                    .createdAt(message.getCreatedAt())
-                    .messageType(message.getMessageType())
-                    .build();
-
-        } catch (NotFoundException | BadRequestException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("MessageResponse 변환 실패: {}", e.getMessage());
-            throw new InternalServerErrorException("MessageResponse 변환 중 서버 오류가 발생했습니다: " + e.getMessage());
-        }
+        return MessageResponse.builder()
+                .messagePk(message.getMessagePk())
+                .userEmail(user.getUserEmail())
+                .userName(user.getUserName())
+                .userProfileImage(user.getProfileImagePath())
+                .content(message.getContent())
+                .createdAt(message.getCreatedAt())
+                .messageType(message.getMessageType())
+                .build();
     }
 
 

--- a/spbackend/src/main/java/com/luminous/aurora/common/error/GlobalExceptionHandler.java
+++ b/spbackend/src/main/java/com/luminous/aurora/common/error/GlobalExceptionHandler.java
@@ -98,7 +98,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     // 처리되지 않은 모든 예외를 500 에러로 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponseDto> handleAllException(Exception e) {
-        log.error("처리되지 않은 예외", e); 
+        log.error("처리되지 않은 예외", e);
         ErrorResponseDto response = new ErrorResponseDto(
                 "예상치 못한 오류가 발생했습니다.",
                 "INTERNAL_SERVER_ERROR",

--- a/spbackend/src/main/java/com/luminous/aurora/common/error/GlobalExceptionHandler.java
+++ b/spbackend/src/main/java/com/luminous/aurora/common/error/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.luminous.aurora.common.error;
 
 import com.luminous.aurora.common.error.exception.*;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
@@ -96,6 +98,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     // 처리되지 않은 모든 예외를 500 에러로 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponseDto> handleAllException(Exception e) {
+        log.error("처리되지 않은 예외", e); 
         ErrorResponseDto response = new ErrorResponseDto(
                 "예상치 못한 오류가 발생했습니다.",
                 "INTERNAL_SERVER_ERROR",

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/controller/UserStateController.java
@@ -1,10 +1,8 @@
 package com.luminous.aurora.userstate.controller;
 
 import com.luminous.aurora.auth.entity.Users;
-import com.luminous.aurora.common.error.exception.ForbiddenException;
 import com.luminous.aurora.member.dto.ChannelMemberResponse;
 import com.luminous.aurora.member.dto.DmRoomResponse;
-import com.luminous.aurora.member.service.MemberService;
 import com.luminous.aurora.userstate.dto.*;
 import com.luminous.aurora.userstate.entity.UserStatus;
 import com.luminous.aurora.userstate.service.UserStateService;
@@ -24,7 +22,6 @@ import java.util.List;
 public class UserStateController {
 
     private final UserStateService userStateService;
-    private final MemberService memberService;
 
     //사용자 상태 조회
     @GetMapping("/status")
@@ -61,27 +58,14 @@ public class UserStateController {
 
     /**
      * 채널 멤버 조회 (권한별 + 상태별 + 가나다순)
-     * - IDOR 방지 : 채널 멤버인지 검증 후 조회
-     * - 미멤버 요청 시 403 Forbidden
      */
     @GetMapping("/channel/{channelPk}/members")
     public ResponseEntity<List<ChannelMemberResponse>> getChannelMembers(
             @PathVariable Integer channelPk,
             @AuthenticationPrincipal Users user) {
-        try {
+        List<ChannelMemberResponse> members = userStateService.getChannelMemberWithStatus(channelPk, user.getUserPk());
 
-            // 채널 멤버가 아니면 403
-            if (!memberService.hasChannelAccess(channelPk, user.getUserPk())) {
-                throw new ForbiddenException("해당 채널에 접근할 권한이 없습니다.");
-            }
-            List<ChannelMemberResponse> members = userStateService.getChannelMemberWithStatus(channelPk);
-
-            return ResponseEntity.ok(members);
-        } catch (ForbiddenException e) {
-            throw e;
-        } catch (Exception e) {
-            return ResponseEntity.status(401).build();
-        }
+        return ResponseEntity.ok(members);
     }
 
 

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateService.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateService.java
@@ -30,7 +30,7 @@ public interface UserStateService {
     // 온라인/자리비움/방해금지 : 권한별로 나누고 가나다순
     // 오프라인 : 권한 구분 없이 가나다순
 
-    List<ChannelMemberResponse> getChannelMemberWithStatus(Integer channelPk);
+    List<ChannelMemberResponse> getChannelMemberWithStatus(Integer channelPk, Integer userPk);
 
     // ===== DM 멤버 조회 ========
     // DM멤버 조회 (최신 메시지순 + 상태 + unreadCount)

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateServiceImpl.java
@@ -2,10 +2,6 @@ package com.luminous.aurora.userstate.service;
 
 import com.luminous.aurora.chat.entity.Message;
 import com.luminous.aurora.chat.repository.MessageRepository;
-import com.luminous.aurora.common.error.exception.BadRequestException;
-import com.luminous.aurora.common.error.exception.ForbiddenException;
-import com.luminous.aurora.common.error.exception.InternalServerErrorException;
-import com.luminous.aurora.common.error.exception.NotFoundException;
 import com.luminous.aurora.member.dto.ChannelMemberResponse;
 import com.luminous.aurora.member.dto.DmRoomResponse;
 import com.luminous.aurora.member.entity.ChannelMember;
@@ -74,22 +70,15 @@ public class UserStateServiceImpl implements UserStateService {
     @Override
     @Transactional
     public void setUserStatus(Integer userPk, UserStatus status) {
-        try {
-            UserState userState = userStateRepository.findByUserPk(userPk)
-                    .orElse(UserState.builder().userPk(userPk).build());
+        UserState userState = userStateRepository.findByUserPk(userPk)
+                .orElse(UserState.builder().userPk(userPk).build());
 
-            userState.setStatus(status);
-            userState.setLastSeen(LocalDateTime.now());
+        userState.setStatus(status);
+        userState.setLastSeen(LocalDateTime.now());
 
-            userStateRepository.save(userState);
+        userStateRepository.save(userState);
 
-            log.info("사용자 상태 설정 : userPk = {}, status = {}", userPk, status);
-        } catch (NotFoundException | BadRequestException | ForbiddenException e) {
-            throw e;  // 나중에 추가될 비즈니스 예외 대비
-        } catch (Exception e) {
-            log.error("사용자 상태 설정 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("사용자 상태 설정 중 서버 오류가 발생했습니다: " + e.getMessage());
-        }
+        log.info("사용자 상태 설정 : userPk = {}, status = {}", userPk, status);
     }
 
     @Override
@@ -130,65 +119,58 @@ public class UserStateServiceImpl implements UserStateService {
 
     @Override
     public List<ChannelMemberResponse> getChannelMemberWithStatus(Integer channelPk) {
-        try {
-            // 1. 채널 Active 멤버 조회
-            List<ChannelMember> members = channelMemberRepository.findByChannelPkAndCStatus(channelPk,"Active");
+        // 1. 채널 Active 멤버 조회
+        List<ChannelMember> members = channelMemberRepository.findByChannelPkAndCStatus(channelPk,"Active");
 
-            // 2. 상태별로 그룹화
-            Map<UserStatus, List<ChannelMember>> statusGroups = new HashMap<>();
-            Map<Integer, UserStatus> statusCache = new HashMap<>();
+        // 2. 상태별로 그룹화
+        Map<UserStatus, List<ChannelMember>> statusGroups = new HashMap<>();
+        Map<Integer, UserStatus> statusCache = new HashMap<>();
 
-            for (ChannelMember member : members) {
-                Integer userPk = member.getUser().getUserPk();
-                UserStatus status = getUserStatus(userPk);
-                statusCache.put(userPk, status);
-                statusGroups.computeIfAbsent(status, k -> new ArrayList<>()).add(member);
-            }
-
-            // 3. 정렬 및 조합
-            List<ChannelMember> result = new ArrayList<>();
-
-            // 온라인/자리비움/방해금지: 권한별로 나누고 가나다순
-            for (UserStatus status : Arrays.asList(UserStatus.ONLINE, UserStatus.AWAY, UserStatus.DND)) {
-                List<ChannelMember> statusMembers = statusGroups.getOrDefault(status, new ArrayList<>());
-
-                // 권한별로 그룹화
-                Map<String, List<ChannelMember>> roleGroups = statusMembers.stream()
-                        .collect(Collectors.groupingBy(ChannelMember::getChannelRole));
-
-                // admin 먼저, member 나중에
-                for (String role : Arrays.asList("admin", "member")) {
-                    List<ChannelMember> roleMembers = roleGroups.getOrDefault(role, new ArrayList<>());
-
-                    // 가나다순 정렬
-                    roleMembers.sort(Comparator.comparing(m -> m.getUser().getUserName()));
-                    result.addAll(roleMembers);
-                }
-            }
-
-            // 오프라인: 권한 구분 없이 가나다순
-            List<ChannelMember> offlineMembers = statusGroups.getOrDefault(UserStatus.OFFLINE, new ArrayList<>());
-            offlineMembers.sort(Comparator.comparing(m -> m.getUser().getUserName()));
-            result.addAll(offlineMembers);
-
-            // 4. DTO 변환
-            return result.stream()
-                    .map(member -> {
-                        return ChannelMemberResponse.builder()
-                                .userName(member.getUser().getUserName())
-                                .userEmail(member.getUser().getUserEmail())
-                                .profileImage(member.getUser().getProfileImagePath())
-                                .channelRole(member.getChannelRole())
-                                .userStatus(statusCache.get(member.getUser().getUserPk()))
-                                .build();
-                    })
-                    .collect(Collectors.toList());
-        } catch (NotFoundException | BadRequestException | ForbiddenException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("채널 멤버 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("채널 멤버 조회 중 서버 오류가 발생했습니다: " + e.getMessage());
+        for (ChannelMember member : members) {
+            Integer userPk = member.getUser().getUserPk();
+            UserStatus status = getUserStatus(userPk);
+            statusCache.put(userPk, status);
+            statusGroups.computeIfAbsent(status, k -> new ArrayList<>()).add(member);
         }
+
+        // 3. 정렬 및 조합
+        List<ChannelMember> result = new ArrayList<>();
+
+        // 온라인/자리비움/방해금지: 권한별로 나누고 가나다순
+        for (UserStatus status : Arrays.asList(UserStatus.ONLINE, UserStatus.AWAY, UserStatus.DND)) {
+            List<ChannelMember> statusMembers = statusGroups.getOrDefault(status, new ArrayList<>());
+
+            // 권한별로 그룹화
+            Map<String, List<ChannelMember>> roleGroups = statusMembers.stream()
+                    .collect(Collectors.groupingBy(ChannelMember::getChannelRole));
+
+            // admin 먼저, member 나중에
+            for (String role : Arrays.asList("admin", "member")) {
+                List<ChannelMember> roleMembers = roleGroups.getOrDefault(role, new ArrayList<>());
+
+                // 가나다순 정렬
+                roleMembers.sort(Comparator.comparing(m -> m.getUser().getUserName()));
+                result.addAll(roleMembers);
+            }
+        }
+
+        // 오프라인: 권한 구분 없이 가나다순
+        List<ChannelMember> offlineMembers = statusGroups.getOrDefault(UserStatus.OFFLINE, new ArrayList<>());
+        offlineMembers.sort(Comparator.comparing(m -> m.getUser().getUserName()));
+        result.addAll(offlineMembers);
+
+        // 4. DTO 변환
+        return result.stream()
+                .map(member -> {
+                    return ChannelMemberResponse.builder()
+                            .userName(member.getUser().getUserName())
+                            .userEmail(member.getUser().getUserEmail())
+                            .profileImage(member.getUser().getProfileImagePath())
+                            .channelRole(member.getChannelRole())
+                            .userStatus(statusCache.get(member.getUser().getUserPk()))
+                            .build();
+                })
+                .collect(Collectors.toList());
     }
 
 
@@ -196,64 +178,59 @@ public class UserStateServiceImpl implements UserStateService {
 
     @Override
     public List<DmRoomResponse> getDmRoomsWithStatus(Integer userPk) {
-        try {
-            // 1. 내 DM 멤버 조회 (최신 메시지순)
-            List<DmMember> myDmMembers = dmMemberRepository.findMyDmRoomsOrderByLastMessage(userPk);
+        // 1. 내 DM 멤버 조회 (최신 메시지순)
+        List<DmMember> myDmMembers = dmMemberRepository.findMyDmRoomsOrderByLastMessage(userPk);
 
-            // 2. 각 DM 방 정보 조합
-            return myDmMembers.stream()
-                    .map(myDmMember -> {
-                        Integer dmRoomPk = myDmMember.getDmRoom().getDmRoomPk();
+        // 2. 각 DM 방 정보 조합
+        return myDmMembers.stream()
+                .map(myDmMember -> {
+                    Integer dmRoomPk = myDmMember.getDmRoom().getDmRoomPk();
 
-                        // 2-1. 상대방 찾기
-                        List<DmMember> allMembers = dmMemberRepository.findByDmRoom_DmRoomPk(dmRoomPk);
-                        DmMember otherMember = allMembers.stream()
-                                .filter(member -> !member.getUser().getUserPk().equals(userPk))
-                                .findFirst()
-                                .orElse(null);
+                    // 2-1. 상대방 찾기
+                    List<DmMember> allMembers = dmMemberRepository.findByDmRoom_DmRoomPk(dmRoomPk);
+                    DmMember otherMember = allMembers.stream()
+                            .filter(member -> !member.getUser().getUserPk().equals(userPk))
+                            .findFirst()
+                            .orElse(null);
 
-                        if (otherMember == null) {
-                            return null;
-                        }
+                    if (otherMember == null) {
+                        return null;
+                    }
 
-                        // 2-2 상대방 상태 조회
-                        Integer otherUserPk = otherMember.getUser().getUserPk();
-                        UserStatus otherUserStatus = getUserStatus(otherUserPk);
+                    // 2-2 상대방 상태 조회
+                    Integer otherUserPk = otherMember.getUser().getUserPk();
+                    UserStatus otherUserStatus = getUserStatus(otherUserPk);
 
-                        // 2-3 마지막 메시지 조회
-                        Message lastMessage = messageRepository
-                                .findLatestMessageInDmRoom(dmRoomPk)
-                                .orElse(null);
+                    // 2-3 마지막 메시지 조회
+                    Message lastMessage = messageRepository
+                            .findLatestMessageInDmRoom(dmRoomPk)
+                            .orElse(null);
 
-                        // 2-4 읽지 않은 메시지 개수
-                        Integer unreadCount = 0;
-                        if (myDmMember.getLastReadMessage() != null) {
-                            Long count = messageRepository.countUnreadMessages(
-                                    dmRoomPk,
-                                    myDmMember.getLastReadMessage().getMessagePk(),
-                                    userPk
-                            );
-                            unreadCount = count.intValue();
-                        }
+                    // 2-4 읽지 않은 메시지 개수
+                    Integer unreadCount = 0;
+                    if (myDmMember.getLastReadMessage() != null) {
+                        Long count = messageRepository.countUnreadMessages(
+                                dmRoomPk,
+                                myDmMember.getLastReadMessage().getMessagePk(),
+                                userPk
+                        );
+                        unreadCount = count.intValue();
+                    }
 
-                        // 2-5 DTO 생성
-                        return DmRoomResponse.builder()
-                                .dmRoomPk(dmRoomPk)
-                                .otherUserEmail(otherMember.getUser().getUserEmail())
-                                .otherUserName(otherMember.getUser().getUserName())
-                                .otherProfileImage(otherMember.getUser().getProfileImagePath())
-                                .isMute(myDmMember.getIsMute())
-                                .userStatus(otherUserStatus)
-                                .lastMessageContent(lastMessage != null ? lastMessage.getContent() : null)
-                                .lastMessageTime(lastMessage != null ? lastMessage.getCreatedAt() : null)
-                                .unreadCount(unreadCount)
-                                .build();
-                    })
-                    .filter(response -> response != null)
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            log.error("DM 목록 조회 실패 : {}", e.getMessage());
-            throw new InternalServerErrorException("DM 목록 조회 중 오류 발생 : " + e.getMessage());
-        }
+                    // 2-5 DTO 생성
+                    return DmRoomResponse.builder()
+                            .dmRoomPk(dmRoomPk)
+                            .otherUserEmail(otherMember.getUser().getUserEmail())
+                            .otherUserName(otherMember.getUser().getUserName())
+                            .otherProfileImage(otherMember.getUser().getProfileImagePath())
+                            .isMute(myDmMember.getIsMute())
+                            .userStatus(otherUserStatus)
+                            .lastMessageContent(lastMessage != null ? lastMessage.getContent() : null)
+                            .lastMessageTime(lastMessage != null ? lastMessage.getCreatedAt() : null)
+                            .unreadCount(unreadCount)
+                            .build();
+                })
+                .filter(response -> response != null)
+                .collect(Collectors.toList());
     }
 }

--- a/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/userstate/service/UserStateServiceImpl.java
@@ -2,12 +2,14 @@ package com.luminous.aurora.userstate.service;
 
 import com.luminous.aurora.chat.entity.Message;
 import com.luminous.aurora.chat.repository.MessageRepository;
+import com.luminous.aurora.common.error.exception.ForbiddenException;
 import com.luminous.aurora.member.dto.ChannelMemberResponse;
 import com.luminous.aurora.member.dto.DmRoomResponse;
 import com.luminous.aurora.member.entity.ChannelMember;
 import com.luminous.aurora.member.entity.DmMember;
 import com.luminous.aurora.member.repository.ChannelMemberRepository;
 import com.luminous.aurora.member.repository.DmMemberRepository;
+import com.luminous.aurora.member.service.MemberService;
 import com.luminous.aurora.userstate.entity.UserState;
 import com.luminous.aurora.userstate.entity.UserStatus;
 import com.luminous.aurora.userstate.repository.UserStateRedisRepository;
@@ -32,6 +34,7 @@ public class UserStateServiceImpl implements UserStateService {
     private final ChannelMemberRepository channelMemberRepository;
     private final DmMemberRepository dmMemberRepository;
     private final MessageRepository messageRepository;
+    private final MemberService memberService;
 
     // ====기본 상태 관리 ====
     @Override
@@ -118,7 +121,11 @@ public class UserStateServiceImpl implements UserStateService {
     // ========== 채널 멤버 조회 ==========
 
     @Override
-    public List<ChannelMemberResponse> getChannelMemberWithStatus(Integer channelPk) {
+    public List<ChannelMemberResponse> getChannelMemberWithStatus(Integer channelPk, Integer userPk) {
+
+        // 채널 멤버가 아니면 403
+        validateChannelAccess(channelPk, userPk);
+
         // 1. 채널 Active 멤버 조회
         List<ChannelMember> members = channelMemberRepository.findByChannelPkAndCStatus(channelPk,"Active");
 
@@ -127,9 +134,9 @@ public class UserStateServiceImpl implements UserStateService {
         Map<Integer, UserStatus> statusCache = new HashMap<>();
 
         for (ChannelMember member : members) {
-            Integer userPk = member.getUser().getUserPk();
-            UserStatus status = getUserStatus(userPk);
-            statusCache.put(userPk, status);
+            Integer memberUserPk = member.getUser().getUserPk();
+            UserStatus status = getUserStatus(memberUserPk);
+            statusCache.put(memberUserPk, status);
             statusGroups.computeIfAbsent(status, k -> new ArrayList<>()).add(member);
         }
 
@@ -232,5 +239,16 @@ public class UserStateServiceImpl implements UserStateService {
                 })
                 .filter(response -> response != null)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 채널 접근 권한 검증
+     *
+     * @throws ForbiddenException 권한 없으면 403
+     */
+    private void validateChannelAccess(Integer channelPk, Integer userPk) {
+        if (!memberService.hasChannelAccess(channelPk, userPk)) {
+            throw new ForbiddenException("해당 채널에 접근할 권한이 없습니다.");
+        }
     }
 }


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> refactor/#214-service-try-catch-cleanup

<br/>

## 🥔 작업 내용

---

### 핵심 변경
- 서비스 레이어 전반에 흩어져 있던 redundant try-catch 블록 제거
- `GlobalExceptionHandler`에 stack trace 로깅 추가하여 미처리 예외도 추적 가능하도록 통합
- 의미 있는 try-catch(캐시 fallback, 토큰 검증 등)는 보존

### 커밋별 변경
- `chore(#214 )`: GlobalExceptionHandler에 처리되지 않은 예외 로깅 추가 (`log.error("처리되지 않은 예외", e)`)
- `refactor(#214 )`: AuthServiceImpl try-catch 제거 (login, signUp, logout, getUserInfo)
- `refactor(#214 )`: TokenServiceImpl try-catch 제거 (validateToken은 비즈니스 로직 보존)
- `refactor(#214 )`: ChatServiceImpl try-catch 제거 (14개 메서드)
- `refactor(#214 )`: UserStateServiceImpl try-catch 제거 (Redis 캐시 fallback은 보존)
- `refactor(#214 )`: UserStateController.getChannelMembers try-catch 제거 (잘못된 401 응답 수정)
- `refactor(#214 )`: UserStateService 권한 검증 service 레이어로 이동 (ChatService 패턴 일치)

### 보존된 try-catch (의도적)
- `TokenServiceImpl.validateToken` — 검증 실패 시 `false` 반환 (비즈니스 로직)
- `UserStateServiceImpl.getUserStatus` — 조회 실패 시 `OFFLINE` fallback
- `UserStateServiceImpl.setUserOnline / setUserAway / setUserOffline` — Redis 캐시 실패해도 흐름 유지

### 부수 효과 (버그 수정)
- `UserStateController.getChannelMembers`가 모든 예외를 401로 변환하던 잘못된 동작 수정
  → 이제 권한 없음은 403, 시스템 오류는 500 + stack trace 로그

<br/>

## 📸 스크린샷 or 영상

(선택사항)

## 💥 확인해주세요!

---

- [ ] 모든 기능이 제대로 동작하는지 확인해주세요.
- [ ] 컨벤션을 제대로 지켰는지 확인해주세요.
- [ ] 모든 화면이 제대로 동작하는지 확인해주세요.

<br/>