### PR TITLE
fix(#227): WebSocket /ws 경로 permitAll — SockJS 연결 허용, STOMP CONNECT에서 인증

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/config/SecurityConfig.java
+++ b/spbackend/src/main/java/com/luminous/aurora/config/SecurityConfig.java
@@ -37,8 +37,7 @@ public class SecurityConfig {
                         .requestMatchers("/").permitAll() // 루트경로 허용
                         .requestMatchers("/api/jv/login","/api/jv/signup","/api/jv/refresh").permitAll() // 인증관련 api 전부 허용
                         .requestMatchers("/api/jv/internal/**").permitAll() // 내부경로 허용
-                        .requestMatchers("/ws/info").permitAll() // 웹소켓 연결을 위한 SockJS 허용
-                        .requestMatchers("/ws/**").authenticated() // Websocket 연결은 인증
+                        .requestMatchers("/ws/**").permitAll() // Websocket 연결은 허용 / 인증 책임은 StompAuthChannelInterceptor로 이관
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> fix/227-websocket-security-permit-stomp-endpoint

<br/>

## 🥔 작업 내용

---

- Spring Security에서 `/ws/**`를 `authenticated()`로 두면 SockJS가 `/ws/info` 이후 호출하는 websocket·xhr 등 하위 경로에서 401이 발생할 수 있음 (브라우저 핸드셰이크에 `Authorization`을 붙이기 어려운 경우).
- `/ws/**`를 `permitAll()`로 변경하고, 사용자 인증은 기존대로 STOMP `CONNECT` 시 `StompAuthChannelInterceptor` + `Authorization: Bearer`로 수행한다.
- REST·기타 API는 기존과 같이 `anyRequest().authenticated()` 유지.

<br/>

## 📸 스크린샷 or 영상

## (선택사항)

- (배포 환경에서 SockJS 연결·채팅 STOMP 동작 확인 시 캡처 첨부)

<br/>

## 💥 확인해주세요!

---

- [ ] 로컬/스테이징에서 SockJS `/ws` 연결 후 STOMP `CONNECT`에 Bearer 포함해 채팅·읽음 등 정상 동작
- [ ] 배포 URL Origin이 CORS·`WebSocketConfig#setAllowedOrigins`와 일치하는지 확인
- [ ] 컨벤션(이슈·브랜치·커밋) 준수

<br/>