### PR TITLE
fix(#231): WebSocket·STOMP principal 정합 및 CONNECT 처리 정리

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatWebSocketController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/controller/ChatWebSocketController.java
@@ -47,7 +47,11 @@ public class ChatWebSocketController {
         if (user == null) {
             throw new UnauthorizedException("인증 정보를 찾을 수 없습니다.");
         }
-
+        
+        Integer userPk = user.getUserPk();
+        if (userPk == null) {
+            throw new UnauthorizedException("인증 정보를 찾을 수 없습니다.");
+        }
         return user.getUserPk();
     }
 

--- a/spbackend/src/main/java/com/luminous/aurora/chat/handler/WebSocketConnectHandler.java
+++ b/spbackend/src/main/java/com/luminous/aurora/chat/handler/WebSocketConnectHandler.java
@@ -1,64 +1,99 @@
 package com.luminous.aurora.chat.handler;
 
-import com.luminous.aurora.auth.repository.UserRepository;
-import com.luminous.aurora.common.error.exception.NotFoundException;
-import com.luminous.aurora.jwt.JwtTokenProvider;
+import com.luminous.aurora.auth.entity.Users;
 import com.luminous.aurora.userstate.service.UserStateService;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
-import java.util.Arrays;
+import java.security.Principal;
 
+
+/**
+ * STOMP(WebSocket) 세션이 맺어졌다/끊겼다 할 때, 사용자 온라인 상태를 UserState 쪽에 반영한다.
+ *
+ * <h2>이 클래스가 하지 않는 것 (중요)</h2>
+ * <ul>
+ *   <li><b>인증(Authentication)</b>을 여기서 하지 않는다. JWT 검증·Bearer 파싱은 전부
+ *       {@link com.luminous.aurora.config.StompAuthChannelInterceptor} 가
+ *       STOMP {@code CONNECT} 프레임이 들어올 때 수행한다.</li>
+ *   <li>예전 설계처럼 HTTP 핸드셰이크에서 {@code access_token} 쿠키를 읽어
+ *       세션 속성 {@code jwt_token}에 넣는 흐름은 폐기되었으므로, 이 처리기는
+ *       {@code jwt_token}을 절대 기대하지 않는다.</li>
+ * </ul>
+ *
+ * <h2>왜 {@code SessionConnectEvent}에서 {@code getUser()}만 보면 되나?</h2>
+ * CONNECT 프레임이 인바운드 채널을 통과할 때 인터셉터가
+ * {@link org.springframework.messaging.simp.stomp.StompHeaderAccessor#setUser(java.security.Principal)}
+ * 로 이미 현재 사용자({@link Users})를 principal로 넣어 두었다.
+ * 그 뒤에 스프링이 {@link SessionConnectEvent}를 발행하므로, 여기서는 그 결과를 <b>존중만</b> 하면 된다.
+ *
+ * <h2>절대 다시 하지 말 것</h2>
+ * {@code jwt_token}이 없다고 {@code headerAccessor.setUser(null)} 을 호출하면,
+ * 방금 인터셉터가 세팅한 principal을 망가뜨려 이후 {@code @AuthenticationPrincipal}·권한 검사가 꼬일 수 있다.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class WebSocketConnectHandler {
-    private final JwtTokenProvider jwtTokenProvider;
-    private final UserRepository userRepository;
+
     private final UserStateService userStateService;
 
-    // WebSocket 연결 시 JWT 토큰을 쿠키에 저장
     @EventListener
     public void handleWebSocketConnectListener(SessionConnectEvent event) {
+        // CONNECT 메시지를 감싼 헤더 접근자. 여기에 native header, user, session attributes가 실린다.
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
         try {
-            // 핸드셰이크에서 저장한 JWT 토큰을 세션에서 가져옴
-            String jwtToken = (String) headerAccessor.getSessionAttributes().get("jwt_token");
-            if (jwtToken != null && jwtTokenProvider.validateToken(jwtToken)) {
-                String userEmail = jwtTokenProvider.getUserEmailFromToken(jwtToken);
-                Integer userPk = userRepository.findUserPkByUserEmail(userEmail)
-                        .orElseThrow(()-> new NotFoundException("사용자를 찾을 수 없습니다."));
-                // JWT가 유효하면 연결 허용
-                headerAccessor.getSessionAttributes().put("authenticated",true);
-                headerAccessor.getSessionAttributes().put("user_pk", userPk);
-                userStateService.setUserOnline(userPk);
-                log.info("WebSocket 연결 성공 : 인증된 사용자 - userEmail ={}", userEmail);
-            } else {
-                log.warn("WebSocket 연결 실패 : 인증 실패");
-                // 연결 거부 처리
-                headerAccessor.setUser(null);
+            // 인터셉터가 CONNECT 시 채워넣은 Spring security Authentication
+            // 아직 null이면 : 이벤트 순서/버전 이슈 가능 -> 아래에서 WARN만 남기고 끝 (principal 망가뜨리지 않음).
+            Principal userPrincipal = headerAccessor.getUser();
+            if (!(userPrincipal instanceof Authentication auth
+                    && auth.getPrincipal() instanceof Users user)) {
+                log.warn("STOMP CONNECT 이후에도 Principal 이 Users가 아님."
+                                + "StompAuthChannelInterceptor-CONNECT 헤더(Bearer)를 확인하세요. sessionId = {}",
+                        headerAccessor.getSessionId());
+                // 주의 : 여기서 setUser(null) 하지 않는다. 인증 실패는 CONNECT 단계에서 이미 거절되었어야 한다
+                return;
             }
+
+            // 연결 해제 시 setUserOffline에 쓰기 위해 세션에 userPk 보관 (기존 disconnect 로직과 호환)
+            headerAccessor.getSessionAttributes().put("authenticated", Boolean.TRUE);
+            headerAccessor.getSessionAttributes().put("user_pk", user.getUserPk());
+
+            // Redis/DB 기반 "접속 중" 표시 (기존 동작 유지).
+            userStateService.setUserOnline(user.getUserPk());
+
+            log.info("WebSocket STOMP 연결 반영: userEmail ={}, userPK={}, sessionId ={}",
+                    user.getUserEmail(), user.getUserPk(), headerAccessor.getSessionId());
         } catch (Exception e) {
-            log.error("WebSocket 연결 처리 중 오류 발생 : {}", e.getMessage());
-            headerAccessor.setUser(null);
+            // 온라인 처리 실패해도 STOMP 세션 자체는 이미 열려 있을 수 있음. -> 로그만 남김
+            log.error("WebSocket 연결 처리 중 오류 발생 : {}", headerAccessor.getSessionId(), e);
         }
     }
 
-    // 웹소켓 연결 해제 시 로깅
+    /**
+     * STOMP 세션 종료 시 호출된다 (탭 닫기, 네트워크 끊김, DISCONNECT 등).
+     */
     @EventListener
     public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
-
         try {
-            // 세션에서 userPk 추출
+            // CONNECT 때 넣어 둔 userPk 우선 사용
             Integer userPk = (Integer) headerAccessor.getSessionAttributes().get("user_pk");
+
+            // 일부 환경에서는 속성만 비어있고 user는 아직 accessor에 남아 있을 수 있어 fallback
+            if (userPk == null) {
+                Principal userPrincipal = headerAccessor.getUser();
+                if (userPrincipal instanceof Authentication auth
+                        && auth.getPrincipal() instanceof Users user) {
+                    userPk = user.getUserPk();
+                }
+            }
             if (userPk != null) {
                 // 사용자를 오프라인 상태로 설정
                 userStateService.setUserOffline(userPk);
@@ -67,7 +102,7 @@ public class WebSocketConnectHandler {
                 log.info("WebSocket 연결 해제 : sessionId={}", headerAccessor.getSessionId());
             }
         } catch (Exception e) {
-            log.error("WebSocket 연결 해제 처리 중 오류 발생 : {}", e.getMessage());
+            log.error("WebSocket 연결 해제 처리 중 오류 발생: sessionId={}", headerAccessor.getSessionId(), e);
         }
     }
 

--- a/spbackend/src/main/java/com/luminous/aurora/config/StompAuthenticationPrincipalArgumentResolver.java
+++ b/spbackend/src/main/java/com/luminous/aurora/config/StompAuthenticationPrincipalArgumentResolver.java
@@ -1,0 +1,88 @@
+package com.luminous.aurora.config;
+
+import com.luminous.aurora.auth.entity.Users;
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.security.Principal;
+import java.util.Optional;
+
+/**
+ * STOMP 메시지 핸들러에서 @AuthenticationPrincipal 과 Users 타입을 함께 쓸 때 주입을 담당한다.
+ *
+ * 배경: 기본 설정에서는 Payload용 리졸버가 @Payload 없는 파라미터도 JSON 본문으로 채우려 한다.
+ * 그래서 Users user 가 실제 로그인 사용자가 아니라 메시지 body 를 Users 로 잘못 맞춘 객체(userPk 만 null 인 빈 객체)가 될 수 있다.
+ *
+ * 이 리졸버는 WebSocketConfig 의 addArgumentResolvers 로 등록해 Payload 리졸버보다 먼저 실행되게 한다.
+ * 값은 오직 STOMP 메시지 헤더에 실린 세션 사용자(Principal) 만 사용한다.
+ *
+ * CONNECT 시점에 StompAuthChannelInterceptor 가 JWT 검증 후 setUser(Authentication) 으로 넣어 둔 principal 과 같은 출처다.
+ */
+public class StompAuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+    /**
+     * 이 리졸버가 해당 파라미터를 처리할지 여부.
+     * 스프링은 등록된 리졸버를 순서대로 두고, true 인 첫 리졸버에게만 resolveArgument 를 넘긴다.
+     * Payload 리졸버가 넓게 잡혀 있어도 여기서 먼저 가로채야 한다.
+     */
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // @AuthenticationPrincipal 이 없으면 "현재 인증 주체" 주입이 아님
+        if (parameter.getParameterAnnotation(AuthenticationPrincipal.class) == null) {
+            return false;
+        }
+
+        // Optional<Users> 면 안쪽 타입 기준으로 판단
+        MethodParameter nested = parameter.nestedIfOptional();
+        Class<?> type = nested.getNestedParameterType();
+
+        // Users 또는 그 하위 타입만 처리
+        return Users.class.isAssignableFrom(type);
+    }
+
+    /**
+     * STOMP 인바운드 메시지 헤더에서 Users 를 꺼내 컨트롤러 인자로 넘긴다.
+     * Optional<Users> 면 값이 없을 때 Optional.empty() 로 돌려준다.
+     */
+    @Override
+    @Nullable
+    public Object resolveArgument(MethodParameter parameter, Message<?> message) {
+        Users user = resolveUsersFromMessage(message);
+
+        if (parameter.isOptional()) {
+            return Optional.ofNullable(user);
+        }
+        return user;
+    }
+
+    /**
+     * 메시지 헤더의 Principal 을 Users 로만 안전하게 바꾼다.
+     *
+     * SimpMessageHeaderAccessor.getUser: 같은 WebSocket STOMP 세션에 묶인 현재 사용자.
+     * CONNECT 때 인터셉터가 넣어 두면 이후 SEND 등에도 같은 사용자가 헤더로 이어진다.
+     *
+     * Principal 선언 타입이어도 실제로는 Authentication 이 오는 경우가 많다.
+     * getPrincipal() 이 Users 일 때만 성공. 그 외는 null 이며 상위에서 인증 실패로 처리하면 된다.
+     */
+    @Nullable
+    private static Users resolveUsersFromMessage(Message<?> message) {
+        Principal principal = SimpMessageHeaderAccessor.getUser(message.getHeaders());
+        if (principal == null) {
+            return null;
+        }
+
+        if (principal instanceof Authentication authentication) {
+            Object p = authentication.getPrincipal();
+            if (p instanceof Users users) {
+                return users;
+            }
+        }
+
+        return null;
+    }
+}

--- a/spbackend/src/main/java/com/luminous/aurora/config/WebSocketConfig.java
+++ b/spbackend/src/main/java/com/luminous/aurora/config/WebSocketConfig.java
@@ -3,11 +3,14 @@ package com.luminous.aurora.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -49,5 +52,15 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(stompAuthChannelInterceptor);
+    }
+
+    /**
+     * @MessageMapping 메서드에 넘길 인자 리졸버를 등록한다.
+     * addArgumentResolvers 로 넣은 리졸버는 기본 목록에서 Payload 리졸버 바로 앞에 끼워 넣어진다.
+     * 그래서 @AuthenticationPrincipal Users 는 JSON 본문이 아니라 STOMP 세션 principal 로만 채운다.
+     */
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(new StompAuthenticationPrincipalArgumentResolver());
     }
 }


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> fix/#231-websocket-connect-handler-stomp-principal-alignment

<br/>

## 🥔 작업 내용

---

- STOMP `CONNECT` 이후 이벤트 및 메시지 핸들러에서 인증 주체를 다룰 때, `StompHeaderAccessor#getUser()` 반환 타입이 `Principal` 인 점을 반영해 `Authentication`·`Users` 로 안전하게 좁히는 방식으로 정리했다. 잘못된 조건식으로 principal 을 망가뜨리거나 타입 불일치 컴파일 오류가 나지 않도록 한다.
- HTTP 핸드셰이크 시점의 인증과 STOMP `CONNECT` 시점의 인증을 분리해 두는 현재 설계를 문서·주석 수준에서 명확히 했다. `jwt_token` 세션 의존을 제거한 뒤, 인증은 `StompAuthChannelInterceptor` 의 Bearer 검증과 세션 `setUser` 결과만 신뢰하는 흐름과 맞췄다.
- `SessionConnectEvent` 처리에서 `setUser(null)` 등으로 인터셉터가 설정한 principal 을 덮어쓰지 않도록 유지하여, 이후 `@AuthenticationPrincipal`·권한 검사와의 정합성을 보장한다.
- 클라이언트는 STOMP `CONNECT` 프레임에 HTTP 헤더와 별도로 `Authorization: Bearer <access token>` 을 네이티브 헤더로 실어야 함을 전제로 한다. WebSocket 101 만으로는 본문 전송 단계의 principal 이 채워지지 않는다.
- `@MessageMapping` 에서 `@AuthenticationPrincipal Users` 가 기본 `PayloadMethodArgumentResolver` 에 의해 JSON 본문으로 잘못 바인딩되어 `userPk` 가 비는 문제를 방지하기 위해, Payload 보다 앞에 동작하는 전용 `HandlerMethodArgumentResolver` 를 등록하는 방안을 적용·정리했다. (해당 클래스 및 `WebSocketConfig#addArgumentResolvers` 포함)
- 필요 시 `requireUserPk` 에서 `user.getUserPk()` 가 null 인 경우를 차단하는 이중 방어를 두어, 권한 검사 전에 식별자 누락으로 오해하기 쉬운 실패를 줄인다.

<br/>

## 📸 스크린샷 or 영상

### 메시지가 정상적으로 전송되는 모습
<img width="1348" height="451" alt="image" src="https://github.com/user-attachments/assets/8315a8f8-4327-4a31-a261-7304b592ed72" />


---

(백엔드 변경 위주이므로 생략 가능. Postman·프론트에서 STOMP CONNECT 헤더 포함 연결 및 채널 SEND 동작 캡처가 있으면 첨부.)

<br/>

## 💥 확인해주세요!

---

- [ ] STOMP `CONNECT` 시 `Authorization: Bearer` 가 네이티브 헤더로 전달되는지, CONNECT 연거부 및 서버 로그에서 인증 성공이 확인되는지 검토해 주세요.
- [ ] 채널·DM WebSocket 송신 및 읽음 처리 등 `@AuthenticationPrincipal Users` 를 쓰는 핸들러가 정상 동작하는지 확인해 주세요.
- [ ] 기존 REST 는 `SecurityContext`(Jwt 필터) 경로, WebSocket STOMP 는 세션 Principal 경로임을 구분해 두었는지 팀 내 공유가 필요하면 문서·코멘트로 남겨 주세요.
- [ ] 브랜치명·이슈 번호(#231)·커밋 메시지 컨벤션이 맞는지 확인해 주세요.

<br/>