### PR TITLE
Feature/#233 refresh token rotation validation

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/auth/controller/AuthController.java
+++ b/spbackend/src/main/java/com/luminous/aurora/auth/controller/AuthController.java
@@ -47,7 +47,7 @@ public class AuthController {
      * <p>
      * 응답 구성 (#225):
      * - Body: {@link AccessTokenResponse} — access token만 포함
-     * - Cookie: {@code refresh_token} (HttpOnly, 7일)
+     * - Cookie: {@code refresh_token} (HttpOnly, 30일)
      * <p>
      * access token은 더 이상 쿠키로 발급하지 않는다.
      * 클라이언트가 body에서 받아 메모리에 보관하고,
@@ -95,7 +95,7 @@ public class AuthController {
      * refresh_token 쿠키를 검증 후 새 access token + 새 refresh token을 발급한다.
      * <p>
      * 응답 구성 (#225):
-     * - Body: 새 access token ({@link AccessTokenResponse})
+     * - Body: 새 access token ({@link AccessTokenResponse}) — 클라이언트는 메모리 access 를 반드시 교체
      * - Cookie: 새 refresh_token (회전)
      * <p>
      * refresh token rotation: TokenService.refreshToken은 항상 새 refresh token을 함께 발급하고

--- a/spbackend/src/main/java/com/luminous/aurora/auth/service/TokenServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/auth/service/TokenServiceImpl.java
@@ -69,13 +69,27 @@ public class TokenServiceImpl implements TokenService {
 
     @Override
     public TokenResponse refreshToken(String refreshToken) {
-        String userEmail = jwtTokenProvider.getUserEmailFromToken(refreshToken);
 
-        // refresh token이 redis에 있는지 확인
-        if (!tokenRedisRepository.hasToken(userEmail + ":refresh")) {
+        // 1) JWT 자체 유효성 (서명,만료) 만료/위조면 여기서 false
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
             throw new UnauthorizedException("유효하지 않은 Refresh Token 입니다.");
         }
-        // 있다면 새로운 토큰 생성
+        // 2) 클레임에서 사용자 식별
+        String userEmail = jwtTokenProvider.getUserEmailFromToken(refreshToken);
+        String refreshKey = userEmail + ":refresh";
+
+        // 3) Redis 에 refresh 키가 없으면 로그아웃,만료,이미 회전된 세션
+        if (!tokenRedisRepository.hasToken(refreshKey)) {
+            throw new UnauthorizedException("유효하지 않은 Refresh Token 입니다.");
+        }
+
+        // 4) 키가 있는지만 확인하는게 아니라(기존방식) 저장된 문자열과 쿠키로 온 refresh가 같은지 확인 (rotation 핵심)
+        String storedRefresh = tokenRedisRepository.getToken(refreshKey);
+        if (storedRefresh == null || !storedRefresh.equals(refreshToken)) {
+            throw new UnauthorizedException("유효하지 않은 Refresh Token 입니다");
+        }
+
+        // 5) 검증 통과 -> access,refresh 둘다 새로 발급 + Redis 덮어쓰기
         return generateTokens(userEmail);
     }
 }

--- a/spbackend/src/main/java/com/luminous/aurora/auth/service/TokenServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/auth/service/TokenServiceImpl.java
@@ -85,7 +85,15 @@ public class TokenServiceImpl implements TokenService {
 
         // 4) 키가 있는지만 확인하는게 아니라(기존방식) 저장된 문자열과 쿠키로 온 refresh가 같은지 확인 (rotation 핵심)
         String storedRefresh = tokenRedisRepository.getToken(refreshKey);
-        if (storedRefresh == null || !storedRefresh.equals(refreshToken)) {
+        if (storedRefresh == null) {
+            throw new UnauthorizedException("유효하지 않은 Refresh Token 입니다");
+        }
+        // 4-1) Redis에 refresh가 있는데 요청과 다름 -> 이미 회전된(옛날) refresh 재사용 가능성
+        if (!storedRefresh.equals(refreshToken)) {
+            tokenRedisRepository.deleteToken(userEmail);
+            tokenRedisRepository.deleteToken(refreshKey);
+            // 정상적인 방법으로는 재사용 안되기 때문에 해킹의심 or 여러 장소에서 같은 아이디 사용 or 비정상적 사용패턴이므로 체크
+            log.warn("Refresh Token 재사용 의심: userEmail ={}", userEmail);
             throw new UnauthorizedException("유효하지 않은 Refresh Token 입니다");
         }
 


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> feature/#233-refresh-token-rotation-validation

<br/>

## 🥔 작업 내용

---

### 배경

`POST /api/jv/refresh` 는 이미 **새 access(body) + 새 refresh(Set-Cookie)** 를 내려주지만, `TokenServiceImpl.refreshToken` 은 Redis에 refresh **키 존재 여부(`hasToken`)만** 확인하고 **쿠키로 온 refresh JWT 문자열과 Redis 저장값이 같은지**는 보지 않았다.  
그 결과 **이미 회전된(구) refresh** 로 재요청해도 JWT 서명·만료만 유효하면 통과할 여지가 있어, rotation 정책과 맞지 않았다.

### 변경 사항

**1. `TokenServiceImpl.refreshToken` — refresh 검증·회전 강화**

- JWT **서명·만료** 검증 (`JwtTokenProvider.validateToken`) 선행
- Redis `token:{userEmail}:refresh` **키 존재** 확인
- Redis **저장 refresh 문자열**과 요청 쿠키 refresh **일치(`equals`)** 검증
- **불일치 + 키 존재** → refresh **재사용 의심**으로 판단  
  → 해당 사용자 **access·refresh Redis 키 모두 삭제** 후 `401 Unauthorized`
- 검증 통과 시 기존과 동일하게 `generateTokens` → **access·refresh 재발급 및 Redis 덮어쓰기**

**2. `AuthController` — 문서·주석 정합**

- login Javadoc: refresh 쿠키 TTL **30일** 로 명시 (코드 `Duration.ofDays(30)` 와 일치)
- refresh Javadoc: 응답 body **access 재발급** 및 클라이언트 **메모리 access 교체** 필요 명시


<br/>