### PR TITLE
refactor(#235) : Redis access 토큰 키 suffix :access 통일

### DIFF
--- a/spbackend/src/main/java/com/luminous/aurora/auth/service/TokenServiceImpl.java
+++ b/spbackend/src/main/java/com/luminous/aurora/auth/service/TokenServiceImpl.java
@@ -33,7 +33,7 @@ public class TokenServiceImpl implements TokenService {
         String refreshToken = jwtTokenProvider.generateRefreshToken(userEmail);
 
         // Redis에 토큰 저장
-        tokenRedisRepository.saveToken(userEmail, accessToken, accessTokenValidity);
+        tokenRedisRepository.saveToken(userEmail + ":access", accessToken, accessTokenValidity);
         tokenRedisRepository.saveToken(userEmail + ":refresh", refreshToken, refreshTokenValidity);
 
         log.info("토큰 생성 완료: userEmail = {}", userEmail);
@@ -53,7 +53,7 @@ public class TokenServiceImpl implements TokenService {
             }
 
             // Redis에 토큰이 존재하는지 확인 (로그아웃 체크)
-            return tokenRedisRepository.hasToken(userEmail);
+            return tokenRedisRepository.hasToken(userEmail + ":access");
         } catch (Exception e) {
             log.error("토큰 검증 실패 : {}", e.getMessage());
             return false;
@@ -62,7 +62,7 @@ public class TokenServiceImpl implements TokenService {
 
     @Override
     public void logout(String userEmail) {
-        tokenRedisRepository.deleteToken(userEmail);
+        tokenRedisRepository.deleteToken(userEmail + ":access");
         tokenRedisRepository.deleteToken(userEmail + ":refresh");
         log.info("로그아웃 완료 : userEmail = {}", userEmail);
     }
@@ -88,9 +88,10 @@ public class TokenServiceImpl implements TokenService {
         if (storedRefresh == null) {
             throw new UnauthorizedException("유효하지 않은 Refresh Token 입니다");
         }
+        String accessKey = userEmail+ ":access";
         // 4-1) Redis에 refresh가 있는데 요청과 다름 -> 이미 회전된(옛날) refresh 재사용 가능성
         if (!storedRefresh.equals(refreshToken)) {
-            tokenRedisRepository.deleteToken(userEmail);
+            tokenRedisRepository.deleteToken(accessKey);
             tokenRedisRepository.deleteToken(refreshKey);
             // 정상적인 방법으로는 재사용 안되기 때문에 해킹의심 or 여러 장소에서 같은 아이디 사용 or 비정상적 사용패턴이므로 체크
             log.warn("Refresh Token 재사용 의심: userEmail ={}", userEmail);


### PR DESCRIPTION
# 🐿️ Merge Requests

## 🪵 작업 브랜치

---

> refactor/-redis-token-key-unification

<br/>

## 🥔 작업 내용

---

### 배경

Redis에 JWT를 저장할 때 access는 `token:{userEmail}`, refresh만 `token:{userEmail}:refresh` 로 **키 규칙이 비대칭**이었다.  
access / refresh를 **같은 패턴(`token:{userEmail}:access` / `:refresh`)** 으로 맞춰 Redis·운영 시 구분을 명확히 한다.

### 변경 사항

- access Redis 키를 `token:{userEmail}` → **`token:{userEmail}:access`** 로 통일
- refresh는 기존과 동일하게 **`token:{userEmail}:refresh`** 유지
- login / refresh / logout / refresh 재사용 무효화 등 **access 키를 쓰는 모든 경로**에 `:access` suffix 반영
- **Repository API는 변경하지 않음** — 기존 `saveToken` / `getToken` / `hasToken` / `deleteToken` 에 키 문자열만 넘기는 방식 유지

### 동작 유지

- #233에서 적용한 refresh rotation 검증(저장값 equals, 재사용 시 access·refresh Redis 삭제) **로직은 유지**, 키 규칙만 변경

### 배포 참고

- 배포 전에 Redis에 남아 있던 **`token:{userEmail}` 형식 access 키**는 더 이상 사용하지 않음
- 배포 직후 일부 사용자는 **재로그인 또는 refresh 1회**가 필요할 수 있음

<br/>

## 📸 스크린샷 or 영상



<br/>